### PR TITLE
Have m3coordinator connect to a Redis instance

### DIFF
--- a/docker/m3coordinator/Dockerfile
+++ b/docker/m3coordinator/Dockerfile
@@ -21,7 +21,16 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 # Provide timezone data to allow TZ environment variable to be set
 # for parsing relative times such as "9am" correctly and respect
 # the TZ environment variable.
+RUN apk update
+RUN apk add --no-cache bash
+RUN apk add --no-cache iperf3
+RUN apk add --no-cache curl
+
 RUN apk add --no-cache tzdata
+
+RUN curl -o /tmp/grpcurl_1.3.1_linux_x86_64.tar.gz -L https://github.com/fullstorydev/grpcurl/releases/download/v1.3.1/grpcurl_1.3.1_linux_x86_64.tar.gz
+RUN tar -xvf /tmp/grpcurl_1.3.1_linux_x86_64.tar.gz
+RUN mv grpcurl /bin
 
 EXPOSE 7201/tcp 7203/tcp
 

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require github.com/mediocregopher/radix/v3 v3.8.0
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/CAFxX/gcnotifier v0.0.0-20190112062741-224a280d589d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1123,6 +1123,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mauricelam/genny v0.0.0-20180903214747-eb2c5232c885 h1:nCU/HIvsORu8nlebFTTkEpxao5zA/yt5Y4yQccm34bM=
 github.com/mauricelam/genny v0.0.0-20180903214747-eb2c5232c885/go.mod h1:wRyVMWiOZeVj+MieWS5tIBBtJ3RtqqMbPsA5Z+t5b5U=
+github.com/mediocregopher/radix/v3 v3.8.0 h1:HI8EgkaM7WzsrFpYAkOXIgUKbjNonb2Ne7K6Le61Pmg=
+github.com/mediocregopher/radix/v3 v3.8.0/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -146,6 +146,9 @@ type Configuration struct {
 	// ListenAddress is the server listen address.
 	ListenAddress *string `yaml:"listenAddress"`
 
+	// RedisAddress is the Redis address for caching.
+	RedisCacheAddress *string `yaml:"redisCacheAddress"`
+
 	// Filter is the read/write/complete tags filter configuration.
 	Filter FilterConfiguration `yaml:"filter"`
 

--- a/src/query/api/v1/handler/prom/prom.go
+++ b/src/query/api/v1/handler/prom/prom.go
@@ -67,10 +67,16 @@ func withEngine(promQLEngineFn options.PromQLEngineFn, instant bool) Option {
 }
 
 func newDefaultOptions(hOpts options.HandlerOptions) opts {
+	// Check if Redis Address exists, otherwise let it be ""
+	redisAddress := ""
+	if hOpts.Config().RedisCacheAddress != nil {
+		redisAddress = *hOpts.Config().RedisCacheAddress
+	}
 	queryable := prometheus.NewPrometheusQueryable(
 		prometheus.PrometheusOptions{
 			Storage:           hOpts.Storage(),
 			InstrumentOptions: hOpts.InstrumentOpts(),
+			RedisCacheAddress: redisAddress,
 		})
 	return opts{
 		queryable:  queryable,

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"time"
+
+	radix "github.com/mediocregopher/radix/v3"
+
+	"go.uber.org/zap"
+)
+
+type RedisCache struct {
+	client       radix.Client
+	redisAddress string
+	logger       *zap.Logger
+}
+
+const (
+	// Minimum number of connections pools to Redis to keep open
+	MinPools int = 10
+	// Time to wait before creating a new Redis connection pool (in ms)
+	CreateAfterTime time.Duration = 100 * time.Millisecond
+)
+
+// Create new RedisCache
+// If redisAddress is "" or a connection can't be made, returns nil
+func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
+	logger.Info("New Cache", zap.String("address", redisAddress))
+	if redisAddress == "" {
+		logger.Info("Not using cache since address is empty")
+		return nil
+	}
+	pool, err := radix.NewPool("tcp", redisAddress, MinPools, radix.PoolOnEmptyCreateAfter(CreateAfterTime))
+	if err != nil {
+		logger.Error("Failed to connect to Redis", zap.String("address", redisAddress))
+		return nil
+	}
+	logger.Info("Connection to Redis established", zap.String("address", redisAddress))
+	return &RedisCache{
+		client:       pool,
+		redisAddress: redisAddress,
+		logger:       logger,
+	}
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Updating m3coordinator so it supports reading a Redis address from config and using it to connect to the Redis server
<!--
   See http://go/pr-description for tips on what to write here
   New to Databricks? See http://go/pr-process

   [NEW] Please review if shiproom approval is required.
   See the Shiproom section below for details.
-->

## How is this tested?
Built and deployed using the process at go/m3dev onto `dev-aws-us-west-1`

Verified the m3coordinator still works as usual when we specify a valid, invalid, or no Redis address.

<!--
  - Added unit or integration tests? Please mention them here.
  - Performed manual testing? Please describe your testing procedure.
  - Was testing unnecessary or not possible? Please explain why.
-->

## How is this feature monitored?
<!--
  - Did you add usage logs or metrics? Please mention them here.
  - Create dashboards or monitoring notebooks? Please link them here.
  - See http://go/obs/user for docs on our observability tools.
-->

#### Code Review
For information about the code review process, e.g. how to find a reviewer or how to ping non-responsive reviewers, check the contents of [go/code-review](http://go/code-review) Confluence page.

#### Approvals
Other than the mandatory approvers enforced by the OWNER file framework (http://go/owners), this PR
requires at least one approval from another engineer.

#### [NEW] Shiproom

**Platform & Compute Fabric**:
Changes should be tracked by an approved "material change." Multiple PRs may be tracked by a single material change.

- [ ] Change modifies code owned or released by a Platform or Compute Fabric team
  - [ ] A "material change" covering this PR exists in http://go/engshiproom: `<CHANGE_ID>`

See http://go/platshiproomwiki for instructions and use http://go/lightcm-template to evaluate risk. Ask questions in #platform-shiproom.

**Runtime changes**:
- [ ] Change targets a runtime maintenance release (i.e., targets a maintenance `dbr-branch-x.x` branch or has a maintenance `dbr-branch-x.x` label)
  - [ ] Change is **NOT** a “material change”
  - [ ] Change **IS** a “material change” of low / medium risk
  - [ ] Change **IS** a “material change” of high risk needing Shiproom review

Please refer Runtime Shiproom Wiki: http://go/runtimeshiproomwiki

#### Security implications
_This section is intended for the reviewers of this PR_
Please, make sure you consider the content of "What are the responsibilities of code reviewers?" section of [go/pr-security-review](http://go/pr-security-review)
