### PR TITLE
Implement remote cache storing whole query

### DIFF
--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
 	// needed for pprof handler registration
 	_ "net/http/pprof"
 	"time"
@@ -46,6 +47,7 @@ import (
 	"github.com/m3db/m3/src/query/api/v1/options"
 	"github.com/m3db/m3/src/query/api/v1/route"
 	"github.com/m3db/m3/src/query/parser/promql"
+	"github.com/m3db/m3/src/query/storage/cache"
 	"github.com/m3db/m3/src/query/util/queryhttp"
 	xdebug "github.com/m3db/m3/src/x/debug"
 	xhttp "github.com/m3db/m3/src/x/net/http"
@@ -350,6 +352,15 @@ func (h *Handler) RegisterRoutes() error {
 		Path:    graphite.FindURL,
 		Handler: h.options.GraphiteFindRouter(),
 		Methods: graphite.FindHTTPMethods,
+	}); err != nil {
+		return err
+	}
+
+	// Enable/Disable Redis endpoint
+	if err := h.registry.Register(queryhttp.RegisterOptions{
+		Path:    cache.ToggleRedisURL,
+		Handler: &cache.RedisToggleHandler{},
+		Methods: methods(cache.ToggleRedisMethods),
 	}); err != nil {
 		return err
 	}

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -20,6 +20,10 @@ const (
 	ExpirationTime string = "300"
 	// Blank result used to denote an empty PromResult
 	EmptyResult string = "{}"
+	// Minimum number of connections pools to Redis to keep open
+	MinPools int = 10
+	// Time to wait before creating a new Redis connection pool (in ms)
+	CreateAfterTime time.Duration = 100 * time.Millisecond
 )
 
 type RedisCache struct {
@@ -36,7 +40,7 @@ func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
 		logger.Info("Not using cache since address is empty")
 		return nil
 	}
-	pool, err := radix.NewPool("tcp", redisAddress, 10, radix.PoolOnEmptyCreateAfter(time.Millisecond*100))
+	pool, err := radix.NewPool("tcp", redisAddress, MinPools, radix.PoolOnEmptyCreateAfter(CreateAfterTime))
 	if err != nil {
 		logger.Error("Failed to connect to Redis", zap.String("address", redisAddress))
 		return nil

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -65,6 +65,8 @@ func keyEncode(query *storage.FetchQuery) string {
 	label_key := strings.Join(res, ";")
 	queryRange := int64(query.End.Sub(query.Start).Seconds())
 	// Key becomes {labels}::{endTime}::{duration}
+	// For example, a key might look like
+	// "fieldA=\"1\";fieldB=\"2\"::1659459470::300"
 	return fmt.Sprintf("%s::%d::%d", label_key, query.End.Unix(), queryRange)
 }
 

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -94,12 +94,13 @@ func NewRedisCache(redisAddress string, logger *zap.Logger, scope tally.Scope) *
 		return nil
 	}
 	logger.Info("Connection to Redis established", zap.String("address", redisAddress))
-	return &RedisCache{
+	cache := &RedisCache{
 		client:       pool,
 		redisAddress: redisAddress,
 		logger:       logger,
 		cacheMetrics: NewCacheMetrics(scope),
 	}
+	return cache
 }
 
 // Given a fetch query, converts it into a key for Redis
@@ -239,7 +240,7 @@ func WindowGetOrFetch(
 	q *storage.FetchQuery,
 	cache *RedisCache,
 ) (storage.PromResult, error) {
-	if cache == nil {
+	if cache == nil || !EnableCache {
 		return st.FetchProm(ctx, q, fetchOptions)
 	}
 	query_range := int64(q.End.Sub(q.Start).Seconds())

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -1,11 +1,25 @@
 package cache
 
 import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/storage"
 	radix "github.com/mediocregopher/radix/v3"
 
 	"go.uber.org/zap"
+)
+
+const (
+	// Time that keys expire after (in seconds)
+	ExpirationTime string = "300"
+	// Blank result used to denote an empty PromResult
+	EmptyResult string = "{}"
 )
 
 type RedisCache struct {
@@ -13,13 +27,6 @@ type RedisCache struct {
 	redisAddress string
 	logger       *zap.Logger
 }
-
-const (
-	// Minimum number of connections pools to Redis to keep open
-	MinPools int = 10
-	// Time to wait before creating a new Redis connection pool (in ms)
-	CreateAfterTime time.Duration = 100 * time.Millisecond
-)
 
 // Create new RedisCache
 // If redisAddress is "" or a connection can't be made, returns nil
@@ -29,7 +36,7 @@ func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
 		logger.Info("Not using cache since address is empty")
 		return nil
 	}
-	pool, err := radix.NewPool("tcp", redisAddress, MinPools, radix.PoolOnEmptyCreateAfter(CreateAfterTime))
+	pool, err := radix.NewPool("tcp", redisAddress, 10, radix.PoolOnEmptyCreateAfter(time.Millisecond*100))
 	if err != nil {
 		logger.Error("Failed to connect to Redis", zap.String("address", redisAddress))
 		return nil
@@ -40,4 +47,168 @@ func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
 		redisAddress: redisAddress,
 		logger:       logger,
 	}
+}
+
+// Given a fetch query, converts it into a key for Redis
+func keyEncode(query *storage.FetchQuery) string {
+	res := make([]string, len(query.TagMatchers))
+	for i, m := range query.TagMatchers {
+		res[i] = m.String()
+	}
+	// Sort to guarantee we have the same order every time
+	sort.Strings(res)
+
+	label_key := strings.Join(res, ";")
+	queryRange := int64(query.End.Sub(query.Start).Seconds())
+	// Key becomes {labels}::{endTime}::{duration}
+	return fmt.Sprintf("%s::%d::%d", label_key, query.End.Unix(), queryRange)
+}
+
+// Given a result, encodes it into string (or "" if error)
+// Encodes an empty PromResult to {} to differentiate from ""
+//
+// We only encode the QueryResult portion of the PromResult struct
+// We omit the metadata since we do not use it in computation
+// and also this metadata also isn't accurate since we aren't getting it from M3DB
+func resultEncode(result *storage.PromResult) (string, error) {
+	if len(result.PromResult.Timeseries) == 0 {
+		return EmptyResult, nil
+	}
+	// Custom Marshal function for QueryResults
+	res, err := result.PromResult.Marshal()
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}
+
+// Given a string, decodes it into a result (or nil if failed)
+//
+// Sets the metadata to a blank as we don't use it
+// and we don't actually have metadata from M3DB for this result
+func resultDecode(val []byte) (*storage.PromResult, error) {
+	var result storage.PromResult
+	result.PromResult = &prompb.QueryResult{}
+
+	// Check length first so we don't convert to string every time
+	if len(val) == len([]byte(EmptyResult)) && string(val) == EmptyResult {
+		result.Metadata = block.NewResultMetadata()
+		return &result, nil
+	}
+	// Custom Unmarshal function for QueryResults
+	if err := result.PromResult.Unmarshal(val); err != nil {
+		return nil, err
+	}
+	result.Metadata = block.NewResultMetadata()
+	return &result, nil
+}
+
+// For each entry in {entries}, gives the PromResult or nil if failed in array
+// Array parameter used to handle multiple bucket requests in the future
+func (cache *RedisCache) Get(entries []*storage.FetchQuery) []*storage.PromResult {
+	keys := make([]string, len(entries))
+	results := make([]*storage.PromResult, len(entries))
+
+	for i, b := range entries {
+		keys[i] = keyEncode(b)
+	}
+
+	// Consume as bytes to avoid having to casting to string later on (avoids duplicate memory)
+	responses := make([][]byte, len(entries))
+	if err := cache.client.Do(radix.Cmd(&responses, "MGET", keys...)); err != nil {
+		cache.logger.Error("Failed to execute Redis batch get", zap.Error(err))
+		return results
+	}
+	for i, r := range responses {
+		// If the response is nil (not EmptyResult), then it doesn't exist
+		if len(r) == 0 {
+			results[i] = nil
+			cache.logger.Info("cache didn't get", zap.String("key", keys[i]))
+			continue
+		}
+		// Otherwise we did find it
+		res, err := resultDecode(r)
+		if err != nil {
+			cache.logger.Error("Redis decode error", zap.Error(err))
+		}
+		results[i] = res
+	}
+	return results
+}
+
+// For each entry in {entries} and associated value in {values},
+// sets entry -> value mapping in Redis
+// Array parameter used to handle multiple bucket requests in the future
+func (cache *RedisCache) Set(
+	entries []*storage.FetchQuery,
+	values []*storage.PromResult,
+) error {
+	var commands []radix.CmdAction
+	// Place holder variable to fit radix.Cmd() functions
+	var response string
+
+	for i := range entries {
+		// Skip over non-existent results
+		if entries[i] == nil {
+			continue
+		}
+		entry := keyEncode(entries[i])
+		value, err := resultEncode(values[i])
+		cache.logger.Info("Prom result size", zap.Int("length", len(value)), zap.Int("ts_len", len(values[i].PromResult.Timeseries)))
+		if err != nil {
+			cache.logger.Error("Redis encode error", zap.Error(err))
+			continue
+		}
+
+		commands = append(commands, radix.Cmd(&response, "SET", entry, value), radix.Cmd(&response, "EXPIRE", entry, ExpirationTime))
+	}
+
+	if err := cache.client.Do(radix.Pipeline(commands...)); err != nil {
+		cache.logger.Error("Failed to execute Redis set", zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+// Function that checks whether the query data is in Redis, and returns that result if present
+// If it is not, it gets the result from M3DB
+//
+// Currently, this check is done by aligning queries to a minute so that queries asking for the
+// same timeseries over the same duration in the same minute are given the same result
+// (i.e. this is the key for Redis)
+func WindowGetOrFetch(
+	ctx context.Context,
+	st storage.Storage,
+	fetchOptions *storage.FetchOptions,
+	q *storage.FetchQuery,
+	cache *RedisCache,
+) (storage.PromResult, error) {
+	if cache == nil {
+		return st.FetchProm(ctx, q, fetchOptions)
+	}
+	query_range := int64(q.End.Sub(q.Start).Seconds())
+	// Align to the current minute
+	align_end := int64(q.End.Unix()/60) * 60
+	// Set start to aligned end minus the query range
+	align_start := align_end - query_range
+
+	align_q := &storage.FetchQuery{
+		TagMatchers: q.TagMatchers,
+		Start:       time.Unix(align_start, 0),
+		End:         time.Unix(align_end, 0),
+	}
+
+	res := cache.Get([]*storage.FetchQuery{align_q})
+	if res[0] == nil {
+		promRes, err := st.FetchProm(ctx, q, fetchOptions)
+		if err == nil {
+			cache.Set([]*storage.FetchQuery{align_q}, []*storage.PromResult{&promRes})
+		}
+
+		cache.logger.Info("cache miss", zap.String("key", keyEncode(align_q)), zap.Int("size", len(promRes.PromResult.Timeseries)))
+		return promRes, err
+	}
+	cache.logger.Info("cache hit", zap.String("key", keyEncode(align_q)))
+	return *res[0], nil
 }

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
 	"github.com/m3db/m3/src/query/storage"
 	radix "github.com/mediocregopher/radix/v3"
+	"github.com/uber-go/tally"
 
 	"go.uber.org/zap"
 )
@@ -20,23 +21,74 @@ const (
 	ExpirationTime string = "300"
 	// Blank result used to denote an empty PromResult
 	EmptyResult string = "{}"
+	// Minimum number of connections pools to Redis to keep open
+	MinPools int = 10
+	// Time to wait before creating a new Redis connection pool (in ms)
+	CreateAfterTime time.Duration = 100 * time.Millisecond
 )
 
 type RedisCache struct {
 	client       radix.Client
 	redisAddress string
 	logger       *zap.Logger
+	cacheMetrics CacheMetrics
+}
+
+// Struct for tracking stats for cache
+type CacheMetrics struct {
+	hitCounter        tally.Counter
+	hitSamplesCounter tally.Counter
+	hitBytesCounter   tally.Counter
+
+	missCounter        tally.Counter
+	missSamplesCounter tally.Counter
+	missBytesCounter   tally.Counter
+}
+
+func NewCacheMetrics(scope tally.Scope) CacheMetrics {
+	subScope := scope.SubScope("cache")
+	return CacheMetrics{
+		hitCounter:        subScope.Counter("hit"),
+		hitSamplesCounter: subScope.Counter("hit-samples"),
+		hitBytesCounter:   subScope.Counter("hit-bytes"),
+
+		missCounter:        subScope.Counter("miss"),
+		missSamplesCounter: subScope.Counter("miss-samples"),
+		missBytesCounter:   subScope.Counter("miss-bytes"),
+	}
+}
+
+// Update metrcis for a cache hit
+func (cm CacheMetrics) CacheMetricsHit(result storage.PromResult) {
+	cm.hitCounter.Inc(1)
+	tot_samples := 0
+	for _, ts := range result.PromResult.Timeseries {
+		tot_samples += len(ts.Samples)
+	}
+	cm.hitSamplesCounter.Inc(int64(tot_samples))
+	cm.hitBytesCounter.Inc(int64(result.PromResult.Size()))
+}
+
+// Update metrics for a cache miss
+func (cm CacheMetrics) CacheMetricsMiss(result storage.PromResult) {
+	cm.missCounter.Inc(1)
+	tot_samples := 0
+	for _, ts := range result.PromResult.Timeseries {
+		tot_samples += len(ts.Samples)
+	}
+	cm.missSamplesCounter.Inc(int64(tot_samples))
+	cm.missBytesCounter.Inc(int64(result.PromResult.Size()))
 }
 
 // Create new RedisCache
 // If redisAddress is "" or a connection can't be made, returns nil
-func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
+func NewRedisCache(redisAddress string, logger *zap.Logger, scope tally.Scope) *RedisCache {
 	logger.Info("New Cache", zap.String("address", redisAddress))
 	if redisAddress == "" {
 		logger.Info("Not using cache since address is empty")
 		return nil
 	}
-	pool, err := radix.NewPool("tcp", redisAddress, 10, radix.PoolOnEmptyCreateAfter(time.Millisecond*100))
+	pool, err := radix.NewPool("tcp", redisAddress, MinPools, radix.PoolOnEmptyCreateAfter(CreateAfterTime))
 	if err != nil {
 		logger.Error("Failed to connect to Redis", zap.String("address", redisAddress))
 		return nil
@@ -46,6 +98,7 @@ func NewRedisCache(redisAddress string, logger *zap.Logger) *RedisCache {
 		client:       pool,
 		redisAddress: redisAddress,
 		logger:       logger,
+		cacheMetrics: NewCacheMetrics(scope),
 	}
 }
 
@@ -207,8 +260,10 @@ func WindowGetOrFetch(
 		}
 
 		cache.logger.Info("cache miss", zap.String("key", keyEncode(align_q)), zap.Int("size", len(promRes.PromResult.Timeseries)))
+		cache.cacheMetrics.CacheMetricsMiss(promRes)
 		return promRes, err
 	}
 	cache.logger.Info("cache hit", zap.String("key", keyEncode(align_q)))
+	cache.cacheMetrics.CacheMetricsHit(*res[0])
 	return *res[0], nil
 }

--- a/src/query/storage/cache/redis_cache_test.go
+++ b/src/query/storage/cache/redis_cache_test.go
@@ -1,0 +1,233 @@
+// Basic unit tests for Redis cache (not comprehensive, just a quick sanity check)
+// This test suite requires setting up a Redis instance at
+// 127.0.0.1:6379 (localhost)
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/storage"
+	radix "github.com/mediocregopher/radix/v3"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+var (
+	cache RedisCache
+)
+
+func TestMain(m *testing.M) {
+	cache = *NewRedisCache("127.0.0.1:6379", zap.NewExample())
+	var response string
+	cache.client.Do(radix.Cmd(&response, "FLUSHALL"))
+	m.Run()
+	cache.client.Do(radix.Cmd(&response, "FLUSHALL"))
+}
+
+func labelsEqual(a, b []prompb.Label) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		val := (string(a[i].Name) == string(b[i].Name) &&
+			string(a[i].Value) == string(b[i].Value))
+		if !val {
+			return false
+		}
+	}
+	return true
+}
+
+func samplesEqual(a, b []prompb.Sample) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		val := (a[i].Timestamp == b[i].Timestamp &&
+			a[i].Value == b[i].Value)
+		if !val {
+			return false
+		}
+	}
+	return true
+}
+
+func timeseriesEqual(a, b []*prompb.TimeSeries) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		val := (labelsEqual(a[i].Labels, b[i].Labels) &&
+			samplesEqual(a[i].Samples, b[i].Samples))
+		if !val {
+			return false
+		}
+	}
+	return true
+}
+
+func resultEqual(a, b *storage.PromResult) bool {
+	return (a.Metadata.Equals(b.Metadata) && timeseriesEqual(a.PromResult.Timeseries, b.PromResult.Timeseries))
+}
+
+func TestSingle(t *testing.T) {
+	tags := []models.Matcher{
+		{Type: models.MatchEqual, Name: []byte("fieldA"), Value: []byte("{")},
+		{Type: models.MatchEqual, Name: []byte("fieldB"), Value: []byte("}")},
+		{Type: models.MatchEqual, Name: []byte("__name__"), Value: []byte("3")},
+	}
+
+	query := storage.FetchQuery{
+		TagMatchers: tags,
+		Start:       time.Unix(0, 0),
+		End:         time.Unix(3600, 0),
+		Interval:    0,
+	}
+
+	result := storage.PromResult{}
+	result.Metadata = block.NewResultMetadata()
+	result.PromResult = &prompb.QueryResult{}
+	result.PromResult.Timeseries = make([]*prompb.TimeSeries, 2)
+
+	result.PromResult.Timeseries[0] = &prompb.TimeSeries{}
+	result.PromResult.Timeseries[0].Samples = []prompb.Sample{
+		{Value: 1, Timestamp: 1},
+		{Value: 1.5, Timestamp: 2},
+		{Value: 2, Timestamp: 3},
+	}
+
+	result.PromResult.Timeseries[0].Labels = []prompb.Label{
+		{Name: []byte("fieldA"), Value: []byte("{")},
+		{Name: []byte("fieldB"), Value: []byte("}")},
+		{Name: []byte("fieldC"), Value: []byte("4")},
+		{Name: []byte("__name__"), Value: []byte("3")},
+	}
+
+	result.PromResult.Timeseries[1] = &prompb.TimeSeries{}
+	result.PromResult.Timeseries[1].Samples = []prompb.Sample{
+		{Value: 1, Timestamp: 2},
+		{Value: 1.5, Timestamp: 3},
+		{Value: 2, Timestamp: 4},
+	}
+
+	result.PromResult.Timeseries[1].Labels = []prompb.Label{
+		{Name: []byte("fieldA"), Value: []byte("{")},
+		{Name: []byte("fieldB"), Value: []byte("}")},
+		{Name: []byte("fieldC"), Value: []byte("5")},
+		{Name: []byte("__name__"), Value: []byte("3")},
+	}
+
+	err := cache.Set([]*storage.FetchQuery{&query}, []*storage.PromResult{&result})
+	require.Nil(t, err, fmt.Sprintf("SET failure: Got %s instead of OK as response", err))
+
+	// Test if right values
+	res := cache.Get([]*storage.FetchQuery{&query})
+	require.NotNil(t, res[0], "Error in decoding PromResult, result is not nil")
+	require.True(t, resultEqual(res[0], &result), "Results did not equal expected")
+
+	// Test for correct empty
+	query.End = time.Unix(7200, 0)
+	res = cache.Get([]*storage.FetchQuery{&query})
+	require.Nil(t, res[0], "Result should've been nil for empty key")
+}
+
+// Test for multiple buckets
+func TestMulti(t *testing.T) {
+	tags := []models.Matcher{
+		{Type: models.MatchEqual, Name: []byte("fieldA"), Value: []byte("1")},
+		{Type: models.MatchEqual, Name: []byte("fieldB"), Value: []byte("2")},
+		{Type: models.MatchEqual, Name: []byte("__name__"), Value: []byte("3")},
+	}
+
+	query1 := storage.FetchQuery{
+		TagMatchers: tags,
+		Start:       time.Unix(0, 0),
+		End:         time.Unix(3600, 0),
+		Interval:    0,
+	}
+
+	query2 := storage.FetchQuery{
+		TagMatchers: tags,
+		Start:       time.Unix(3600, 0),
+		End:         time.Unix(7200, 0),
+		Interval:    0,
+	}
+
+	result1 := storage.PromResult{}
+	result1.Metadata = block.NewResultMetadata()
+	result1.PromResult = &prompb.QueryResult{}
+	result1.PromResult.Timeseries = make([]*prompb.TimeSeries, 1)
+
+	result1.PromResult.Timeseries[0] = &prompb.TimeSeries{}
+	result1.PromResult.Timeseries[0].Samples = []prompb.Sample{
+		{Value: 1, Timestamp: 1},
+		{Value: 1.5, Timestamp: 2},
+		{Value: 2, Timestamp: 3},
+	}
+
+	result1.PromResult.Timeseries[0].Labels = []prompb.Label{
+		{Name: []byte("fieldA"), Value: []byte("1")},
+		{Name: []byte("fieldB"), Value: []byte("2")},
+		{Name: []byte("fieldC"), Value: []byte("4")},
+		{Name: []byte("__name__"), Value: []byte("3")},
+	}
+
+	result2 := storage.PromResult{}
+	result2.Metadata = block.NewResultMetadata()
+	result2.PromResult = &prompb.QueryResult{}
+	result2.PromResult.Timeseries = make([]*prompb.TimeSeries, 1)
+
+	result2.PromResult.Timeseries[0] = &prompb.TimeSeries{}
+	result2.PromResult.Timeseries[0].Samples = []prompb.Sample{
+		{Value: 2, Timestamp: 1},
+		{Value: 2.5, Timestamp: 2},
+		{Value: 3, Timestamp: 3},
+	}
+
+	result2.PromResult.Timeseries[0].Labels = []prompb.Label{
+		{Name: []byte("fieldA"), Value: []byte("1")},
+		{Name: []byte("fieldB"), Value: []byte("2")},
+		{Name: []byte("fieldC"), Value: []byte("4")},
+		{Name: []byte("__name__"), Value: []byte("3")},
+	}
+
+	err := cache.Set([]*storage.FetchQuery{&query1, &query2}, []*storage.PromResult{&result1, &result2})
+	require.Nil(t, err, fmt.Sprintf("SET failure: Got %s instead of OK as response", err))
+
+	// Test if right values
+	res := cache.Get([]*storage.FetchQuery{&query1, &query2})
+	require.NotNil(t, res[0], "Error in decoding PromResult, result is not nil")
+	require.True(t, resultEqual(res[0], &result1), "Results did not equal expected")
+	require.NotNil(t, res[1], "Error in decoding PromResult, result is not nil")
+	require.True(t, resultEqual(res[1], &result2), "Results did not equal expected")
+
+	// Test empty is correct
+	query3 := storage.FetchQuery{
+		TagMatchers: tags,
+		Start:       time.Unix(0, 0),
+		End:         time.Unix(7200, 0),
+		Interval:    0,
+	}
+	query4 := storage.FetchQuery{
+		TagMatchers: tags,
+		Start:       time.Unix(0, 0),
+		End:         time.Unix(1800, 0),
+		Interval:    0,
+	}
+	query5 := storage.FetchQuery{
+		TagMatchers: tags,
+		Start:       time.Unix(1800, 0),
+		End:         time.Unix(5400, 0),
+		Interval:    0,
+	}
+	res = cache.Get([]*storage.FetchQuery{&query3, &query4, &query5})
+	require.Nil(t, res[0], "Result should've been nil for empty key")
+	require.Nil(t, res[1], "Result should've been nil for empty key")
+	require.Nil(t, res[2], "Result should've been nil for empty key")
+}

--- a/src/query/storage/cache/redis_cache_test.go
+++ b/src/query/storage/cache/redis_cache_test.go
@@ -1,4 +1,4 @@
-// Basic unit tests for Redis cache (not comprehensive, just a quick sanity check)
+// Simple unit tests for Redis cache
 // This test suite requires setting up a Redis instance at
 // 127.0.0.1:6379 (localhost)
 
@@ -15,6 +15,7 @@ import (
 	"github.com/m3db/m3/src/query/storage"
 	radix "github.com/mediocregopher/radix/v3"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -23,7 +24,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	cache = *NewRedisCache("127.0.0.1:6379", zap.NewExample())
+	cache = *NewRedisCache("127.0.0.1:6379", zap.NewExample(), tally.NewTestScope("", make(map[string]string, 0)))
 	var response string
 	cache.client.Do(radix.Cmd(&response, "FLUSHALL"))
 	m.Run()

--- a/src/query/storage/cache/redis_toggle_handler.go
+++ b/src/query/storage/cache/redis_toggle_handler.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+const (
+	ToggleRedisURL     = "/api/v1/redis/toggle"
+	ToggleRedisMethods = "POST"
+)
+
+var EnableCache = true
+
+type RedisToggleHandler struct{}
+
+func (h *RedisToggleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	toggleVal := r.FormValue("toggle")
+	toggle, err := strconv.ParseBool(toggleVal)
+	if err != nil {
+		fmt.Fprintf(w, "Couldn't parse request")
+		return
+	}
+	fmt.Fprintf(w, "OK: Toggling from %t to %t", EnableCache, toggle)
+	EnableCache = toggle
+}

--- a/src/query/storage/prometheus/prometheus_storage.go
+++ b/src/query/storage/prometheus/prometheus_storage.go
@@ -144,7 +144,8 @@ func (q *querier) Select(
 		return promstorage.ErrSeriesSet(err)
 	}
 
-	result, err := q.storage.FetchProm(q.ctx, query, fetchOptions)
+	// result, err := q.storage.FetchProm(q.ctx, query, fetchOptions)
+	result, err := cache.WindowGetOrFetch(q.ctx, q.storage, fetchOptions, query, q.cache)
 	if err != nil {
 		return promstorage.ErrSeriesSet(NewStorageErr(err))
 	}

--- a/src/query/storage/prometheus/prometheus_storage.go
+++ b/src/query/storage/prometheus/prometheus_storage.go
@@ -87,7 +87,7 @@ func NewPrometheusQueryable(opts PrometheusOptions) promstorage.Queryable {
 		storage: opts.Storage,
 		scope:   scope,
 		logger:  opts.InstrumentOptions.Logger(),
-		cache:   cache.NewRedisCache(opts.RedisCacheAddress, opts.InstrumentOptions.Logger()),
+		cache:   cache.NewRedisCache(opts.RedisCacheAddress, opts.InstrumentOptions.Logger(), scope),
 	}
 }
 

--- a/src/query/storage/prometheus/prometheus_storage_test.go
+++ b/src/query/storage/prometheus/prometheus_storage_test.go
@@ -163,3 +163,130 @@ func TestSelectWithMetaInContext(t *testing.T) {
 	// NB: assert warnings on context were propagated.
 	assert.Equal(t, []string{"warn_warning"}, res.WarningStrings())
 }
+
+// Will need local Redis server on port 6379 for this test
+func TestWindowGet(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	var resMutex sync.Mutex
+	res := block.NewResultMetadata()
+	resultMetadataReceiveFn := func(m block.ResultMetadata) {
+		resMutex.Lock()
+		defer resMutex.Unlock()
+		res = res.CombineMetadata(m)
+	}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, FetchOptionsContextKey, storage.NewFetchOptions())
+	ctx = context.WithValue(ctx, BlockResultMetadataFnKey, resultMetadataReceiveFn)
+
+	store := storage.NewMockStorage(ctrl)
+	opts := PrometheusOptions{
+		Storage:           store,
+		InstrumentOptions: instrument.NewOptions(),
+		RedisCacheAddress: "127.0.0.1:6379",
+	}
+
+	queryable := NewPrometheusQueryable(opts)
+	q, err := queryable.Querier(ctx, 0, 0)
+	require.NoError(t, err)
+
+	if check, ok := q.(*querier); ok {
+		check.cache.FlushAll()
+	}
+
+	start := int64(100)
+	end := int64(1200)
+	step := int64(time.Second)
+
+	hints := &promstorage.SelectHints{
+		Start: start * 1000,
+		End:   end * 1000,
+
+		Step: step / int64(time.Millisecond),
+	}
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+		labels.MustNewMatcher(labels.MatchRegexp, "qux", "q.z"),
+	}
+
+	m, err := models.NewMatcher(models.MatchEqual, []byte("foo"), []byte("bar"))
+	require.NoError(t, err)
+	m2, err := models.NewMatcher(models.MatchRegexp, []byte("qux"), []byte("q.z"))
+	require.NoError(t, err)
+
+	exQuery := &storage.FetchQuery{
+		TagMatchers: models.Matchers{m, m2},
+		Start:       time.Unix(start, 0),
+		End:         time.Unix(end, 0),
+		Interval:    time.Duration(step),
+	}
+
+	meta := block.NewResultMetadata()
+	meta.AddWarning("warn", "warning")
+	store.EXPECT().FetchProm(ctx, exQuery, gomock.Any()).DoAndReturn(
+		func(_ context.Context, arg1 *storage.FetchQuery, _ *storage.FetchOptions) (storage.PromResult, error) {
+			return storage.PromResult{
+				Metadata: meta,
+				PromResult: &prompb.QueryResult{
+					Timeseries: []*prompb.TimeSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: []byte("foo"), Value: []byte("bar")},
+								{Name: []byte("qux"), Value: []byte("qzz")},
+							},
+							Samples: []prompb.Sample{
+								{Value: 1, Timestamp: 100},
+							},
+						},
+						{
+							Labels: []prompb.Label{
+								{Name: []byte("foo"), Value: []byte("bar")},
+								{Name: []byte("qux"), Value: []byte("qaz")},
+							},
+							Samples: []prompb.Sample{
+								{Value: 100, Timestamp: 200},
+							},
+						},
+					},
+				},
+			}, nil
+		})
+
+	series := q.Select(true, hints, matchers...)
+	assert.NoError(t, series.Err())
+
+	// Rerun, result should be cached so we should get results despite no M3DB connection
+	series = q.Select(true, hints, matchers...)
+	assert.NoError(t, series.Err())
+
+	type dp struct {
+		v float64
+		t int64
+	}
+
+	acDp := make([][]dp, 0, 2)
+	acTags := make([]string, 0, 2)
+	for series.Next() {
+		curr := series.At()
+		acTags = append(acTags, curr.Labels().String())
+		it := curr.Iterator()
+		ac := make([]dp, 0, 1)
+		for it.Next() {
+			t, v := it.At()
+			ac = append(ac, dp{t: t, v: v})
+		}
+
+		assert.NoError(t, it.Err())
+		acDp = append(acDp, ac)
+	}
+
+	assert.NoError(t, series.Err())
+
+	exDp := [][]dp{{{v: 100, t: 200}}, {{v: 1, t: 100}}}
+	exTags := []string{`{foo="bar", qux="qaz"}`, `{foo="bar", qux="qzz"}`}
+	assert.Equal(t, exTags, acTags)
+	assert.Equal(t, exDp, acDp)
+	require.NoError(t, q.Close())
+}

--- a/src/query/storage/prometheus/prometheus_storage_test.go
+++ b/src/query/storage/prometheus/prometheus_storage_test.go
@@ -252,12 +252,13 @@ func TestWindowGet(t *testing.T) {
 					},
 				},
 			}, nil
-		})
+		}).MaxTimes(1)
 
 	series := q.Select(true, hints, matchers...)
 	assert.NoError(t, series.Err())
 
-	// Rerun, result should be cached so we should get results despite no M3DB connection
+	// Rerun, result should be cached so we should not have to FetchProm again
+	// If we do, since Max is 1, we will hit error
 	series = q.Select(true, hints, matchers...)
 	assert.NoError(t, series.Err())
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Implementing a remote cache version of the [hackathon cache](https://docs.google.com/document/d/1X4Oiry-aWWfb6EwPh6QyeM0cK7NEO3HxBkWk-mWWRd8/edit#heading=h.g7ieoocb671f). We store results in a remote Redis server.

<!--
   See http://go/pr-description for tips on what to write here
   New to Databricks? See http://go/pr-process

   [NEW] Please review if shiproom approval is required.
   See the Shiproom section below for details.
-->

## How is this tested?
Tested using comparison test at go/m3dev

Deployed to `dev-aws-us-west-1`. Monitored performance metrics on [dashboard](https://grafana.cloud.databricks.com/d/jfb0fkenz/m3coordinator-cache-monitoring?orgId=1&from=now-1h&to=now). Observed caching rate similar to local hackathon cache rate

Was able to turn off Redis caching (checked logs to verify that caching was/wasn't used) by exec-ing the following command (in the pod):
`curl -X POST -F "toggle={true/false}" http://localhost:7201/api/v1/redis/toggle`

True means use the cache, False means don't
<!--
  - Added unit or integration tests? Please mention them here.
  - Performed manual testing? Please describe your testing procedure.
  - Was testing unnecessary or not possible? Please explain why.
-->

## How is this feature monitored?
<!--
  - Did you add usage logs or metrics? Please mention them here.
  - Create dashboards or monitoring notebooks? Please link them here.
  - See http://go/obs/user for docs on our observability tools.
-->

#### Code Review
For information about the code review process, e.g. how to find a reviewer or how to ping non-responsive reviewers, check the contents of [go/code-review](http://go/code-review) Confluence page.

#### Approvals
Other than the mandatory approvers enforced by the OWNER file framework (http://go/owners), this PR
requires at least one approval from another engineer.

#### [NEW] Shiproom

**Platform & Compute Fabric**:
Changes should be tracked by an approved "material change." Multiple PRs may be tracked by a single material change.

- [ ] Change modifies code owned or released by a Platform or Compute Fabric team
  - [ ] A "material change" covering this PR exists in http://go/engshiproom: `<CHANGE_ID>`

See http://go/platshiproomwiki for instructions and use http://go/lightcm-template to evaluate risk. Ask questions in #platform-shiproom.

**Runtime changes**:
- [ ] Change targets a runtime maintenance release (i.e., targets a maintenance `dbr-branch-x.x` branch or has a maintenance `dbr-branch-x.x` label)
  - [ ] Change is **NOT** a “material change”
  - [ ] Change **IS** a “material change” of low / medium risk
  - [ ] Change **IS** a “material change” of high risk needing Shiproom review

Please refer Runtime Shiproom Wiki: http://go/runtimeshiproomwiki

#### Security implications
_This section is intended for the reviewers of this PR_
Please, make sure you consider the content of "What are the responsibilities of code reviewers?" section of [go/pr-security-review](http://go/pr-security-review)
