### PR TITLE
Add query sampling for checking

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3/src/query/graphite/graphite"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
+	"github.com/m3db/m3/src/query/storage/cache"
 	"github.com/m3db/m3/src/query/storage/m3"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
 	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
@@ -146,8 +147,8 @@ type Configuration struct {
 	// ListenAddress is the server listen address.
 	ListenAddress *string `yaml:"listenAddress"`
 
-	// RedisAddress is the Redis address for caching.
-	RedisCacheAddress *string `yaml:"redisCacheAddress"`
+	// Specifies the settings for Redis cache-enabled coordinators
+	RedisCacheSpec *cache.RedisCacheSpec `yaml:"redisCacheSpec"`
 
 	// Filter is the read/write/complete tags filter configuration.
 	Filter FilterConfiguration `yaml:"filter"`

--- a/src/query/api/v1/handler/prom/prom.go
+++ b/src/query/api/v1/handler/prom/prom.go
@@ -69,8 +69,8 @@ func withEngine(promQLEngineFn options.PromQLEngineFn, instant bool) Option {
 func newDefaultOptions(hOpts options.HandlerOptions) opts {
 	// Check if Redis Address exists, otherwise let it be ""
 	redisAddress := ""
-	if hOpts.Config().RedisCacheAddress != nil {
-		redisAddress = *hOpts.Config().RedisCacheAddress
+	if hOpts.Config().RedisCacheSpec != nil && hOpts.Config().RedisCacheSpec.RedisCacheAddress != "" {
+		redisAddress = hOpts.Config().RedisCacheSpec.RedisCacheAddress
 	}
 	queryable := prometheus.NewPrometheusQueryable(
 		prometheus.PrometheusOptions{

--- a/src/query/storage/cache/redis_cache.go
+++ b/src/query/storage/cache/redis_cache.go
@@ -27,6 +27,17 @@ const (
 	CreateAfterTime time.Duration = 100 * time.Millisecond
 )
 
+type RedisCacheSpec struct {
+	// RedisAddress is the Redis address for caching.
+	RedisCacheAddress string `yaml:"redisCacheAddress"`
+
+	// The % of queries we check against the result using only M3DB
+	CheckSampleRate float64 `yaml:"checkSampleRate"`
+
+	// The % diff threshold to declare inequality
+	ComparePercentThreshold float64 `yaml:"comparePercentThreshold"`
+}
+
 type RedisCache struct {
 	client       radix.Client
 	redisAddress string
@@ -94,13 +105,12 @@ func NewRedisCache(redisAddress string, logger *zap.Logger, scope tally.Scope) *
 		return nil
 	}
 	logger.Info("Connection to Redis established", zap.String("address", redisAddress))
-	cache := &RedisCache{
+	return &RedisCache{
 		client:       pool,
 		redisAddress: redisAddress,
 		logger:       logger,
 		cacheMetrics: NewCacheMetrics(scope),
 	}
-	return cache
 }
 
 // Given a fetch query, converts it into a key for Redis

--- a/src/query/storage/prometheus/prometheus_storage.go
+++ b/src/query/storage/prometheus/prometheus_storage.go
@@ -145,9 +145,16 @@ func (q *querier) Select(
 	}
 
 	// result, err := q.storage.FetchProm(q.ctx, query, fetchOptions)
-	result, err := cache.WindowGetOrFetch(q.ctx, q.storage, fetchOptions, query, q.cache)
-	if err != nil {
-		return promstorage.ErrSeriesSet(NewStorageErr(err))
+	useM3DB := q.ctx.Value("UseM3DB")
+	var result storage.PromResult
+	var e error
+	if useM3DB != nil && useM3DB.(bool) {
+		result, e = q.storage.FetchProm(q.ctx, query, fetchOptions)
+	} else {
+		result, e = cache.WindowGetOrFetch(q.ctx, q.storage, fetchOptions, query, q.cache)
+	}
+	if e != nil {
+		return promstorage.ErrSeriesSet(NewStorageErr(e))
 	}
 	seriesSet := fromQueryResult(sortSeries, result.PromResult, result.Metadata)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Implementing a method to periodically check results against the expected M3DB result and record metrics (+refactor of config).

<!--
   See http://go/pr-description for tips on what to write here
   New to Databricks? See http://go/pr-process

   [NEW] Please review if shiproom approval is required.
   See the Shiproom section below for details.
-->

## How is this tested?

Deployed to `dev-aws-us-west-1`, verified from emitted metrics that checks are being performed and are accurate (also verified that mismatches are registered). Other performance metrics aren't affected.

<!--
  - Added unit or integration tests? Please mention them here.
  - Performed manual testing? Please describe your testing procedure.
  - Was testing unnecessary or not possible? Please explain why.
-->

## How is this feature monitored?
<!--
  - Did you add usage logs or metrics? Please mention them here.
  - Create dashboards or monitoring notebooks? Please link them here.
  - See http://go/obs/user for docs on our observability tools.
-->

#### Code Review
For information about the code review process, e.g. how to find a reviewer or how to ping non-responsive reviewers, check the contents of [go/code-review](http://go/code-review) Confluence page.

#### Approvals
Other than the mandatory approvers enforced by the OWNER file framework (http://go/owners), this PR
requires at least one approval from another engineer.

#### [NEW] Shiproom

**Platform & Compute Fabric**:
Changes should be tracked by an approved "material change." Multiple PRs may be tracked by a single material change.

- [ ] Change modifies code owned or released by a Platform or Compute Fabric team
  - [ ] A "material change" covering this PR exists in http://go/engshiproom: `<CHANGE_ID>`

See http://go/platshiproomwiki for instructions and use http://go/lightcm-template to evaluate risk. Ask questions in #platform-shiproom.

**Runtime changes**:
- [ ] Change targets a runtime maintenance release (i.e., targets a maintenance `dbr-branch-x.x` branch or has a maintenance `dbr-branch-x.x` label)
  - [ ] Change is **NOT** a “material change”
  - [ ] Change **IS** a “material change” of low / medium risk
  - [ ] Change **IS** a “material change” of high risk needing Shiproom review

Please refer Runtime Shiproom Wiki: http://go/runtimeshiproomwiki

#### Security implications
_This section is intended for the reviewers of this PR_
Please, make sure you consider the content of "What are the responsibilities of code reviewers?" section of [go/pr-security-review](http://go/pr-security-review)
