### PR TITLE
[DB-M3Coordinator] Add feature to disable downsampling for all metrics by default

### DIFF
--- a/docker/m3coordinator/Dockerfile
+++ b/docker/m3coordinator/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache iperf3
 RUN apk add --no-cache curl
 
 RUN apk add --no-cache tzdata
+RUN apk add --no-cache tar
 
 RUN curl -o /tmp/grpcurl_1.3.1_linux_x86_64.tar.gz -L https://github.com/fullstorydev/grpcurl/releases/download/v1.3.1/grpcurl_1.3.1_linux_x86_64.tar.gz
 RUN tar -xvf /tmp/grpcurl_1.3.1_linux_x86_64.tar.gz

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -74,6 +74,8 @@ type SampleAppenderOptions struct {
 	Override         bool
 	OverrideRules    SamplesAppenderOverrideRules
 	SeriesAttributes ts.SeriesAttributes
+	// option for coordinator to append all metric to downsampler, default is false
+	downsampleAll bool
 }
 
 // SamplesAppenderOverrideRules provides override rules to

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -334,7 +334,8 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 	//    if so then skip aggregating for that storage policy.
 	//    This is what we calculated in the step above.
 	// 2. Any type of drop rule has been set. Drop rules should mean that the auto-mapping rules are ignored.
-	if !a.curr.Pipelines.IsDropPolicySet() {
+	// 3. Aggregate default metric when only downsample option is enable
+	if opts.downsampleAll && !a.curr.Pipelines.IsDropPolicySet() {
 		// No drop rule has been set as part of rule matching.
 		for idx, stagedMetadatasProto := range a.defaultStagedMetadatasProtos {
 			// NB(r): Need to take copy of default staged metadatas as we


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add feature to disable downsampling for all metrics by default. 

When M3Coordinator match results for downsampling and pass to aggregation appender, this change disable the downsampling for the new storage policy by default, like 1m, aggregation will be only for defined aggregated rules which are applied from the interfaces: https://docs.google.com/document/d/1tCf3UTqPtUKci4u3zMaP0jbGd7LkGrTVet0AjaqaWBw/edit#bookmark=kix.w34zirn66h7s

Original design is to add a metric whitelisting section that users can whitelist the metrics need to be pre-aggregation, like current [k2p](https://github.com/databricks/universe/blob/9fe0c7554720a4b34647ced63e3daa8655587024/monitoring/kinesis2prom/service/metric-whitelist.jsonnet.TEMPLATE#L54). While this information we also can get from user provided interface, now we are getting this whitelist information from the rules (interface used by users) to figure out the metric need to be pre-aggregated.

By default, `downsampleAll` flag will be disable. For long term, this can be part of m3 coordinator config if need. 

### Components
M3Coordinator

### How is this tested?

1. All existing downsample unit tests passed
```
PASS
ok  	github.com/m3db/m3/src/cmd/services/m3coordinator/downsample	31.696s
```
3. Added unit tests to ensure this block default metric and no impact for aggregation rules metrics.

![Screen Shot 2022-09-19 at 9 22 57 PM](https://user-images.githubusercontent.com/5896536/191166995-3f5e11e8-25f4-42d9-8846-b758ad02f9a4.png)

4. Applied to dev-dev with pre-aggregation, defined pre-aggregation are still aggregating while other metrics are dropped from appenders.

![Screen Shot 2022-09-19 at 9 19 32 PM](https://user-images.githubusercontent.com/5896536/191166853-270b7ea5-2eb6-4133-b77e-a7609f990c53.png)

