### PR TITLE
[DB-M3Aggregator] Disable the metric latency check and drop in the m3aggregator

### DIFF
--- a/docker/m3aggregator/Dockerfile
+++ b/docker/m3aggregator/Dockerfile
@@ -18,6 +18,21 @@ RUN cd /go/src/github.com/m3db/m3/ && \
 FROM alpine:3.15
 LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk update
+RUN apk add --no-cache bash
+RUN apk add --no-cache iperf3
+RUN apk add --no-cache curl
+
+RUN apk add --no-cache tzdata
+RUN apk add --no-cache tar
+
+RUN curl -o /tmp/grpcurl_1.3.1_linux_x86_64.tar.gz -L https://github.com/fullstorydev/grpcurl/releases/download/v1.3.1/grpcurl_1.3.1_linux_x86_64.tar.gz
+RUN tar -xvf /tmp/grpcurl_1.3.1_linux_x86_64.tar.gz
+RUN mv grpcurl /bin
+
 EXPOSE 5000/tcp 6000/tcp 6001/tcp
 
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
### What changes are proposed in this pull request?

So far in m3 system, there are multiple place to drop the metric. 

1. Coordinator - check remote-write 15m
2. after aggregated before m3db write 15m
3. M3aggregation in each pipeline writing.

This need team to tune the configuration in multiple places, and metric could be dropped accidentally and silence in a component. We should only let coordinator to decide whether metric is too old to write to m3db and disable the latency check in the m3aggregator. Otherwise team need to keep this knowledge cross components and tune the configuration in multiple places.  We will still keep the metric for the visibility. 

In my dev-dev testing, some metric missing in m3 aggregator because of some high latency spikes.

### Components
M3Coordinator

### How is this tested?
deployed in dev-dev, no metric dropping.