### PR TITLE
[PLAT-67042] enhance write path attribution with filtering capability

### DIFF
--- a/src/x/instrument/config.go
+++ b/src/x/instrument/config.go
@@ -62,6 +62,9 @@ type AttributionConfiguration struct {
 
 	// Matched labels of this attribution
 	Labels []string `yaml:"labels"`
+
+	// Filter metrics for attribution
+	Filters []string `yaml:"filters"`
 }
 
 // MetricsConfiguration configures options for emitting metrics.


### PR DESCRIPTION
Plan to enable write path sample attribution. This PR adds capability to filter samples for different attribution jobs.

For example, we want to attribute DP metrics based on project and CP metrics based on kubernetes_namespace, the config will be updated to:
```
attributions:
- name: dataplane
  capacity: 20
  samplingRate: 1
  labels: ["project"]
  filters: ["proxy=kinesis2prom"]
- name: controlplane
  capacity: 50
  samplingRate: 1
  labels: ["kubernetes_namespace"]
```

Added unit test:

Running tool: /usr/local/bin/go test -timeout 30s -run ^TestPromAttributionMetrics_Filters$ github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote

=== RUN   TestPromAttributionMetrics_Filters
--- PASS: TestPromAttributionMetrics_Filters (0.00s)
PASS
ok      github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote   0.726s

> Test run finished at 10/21/2022, 5:49:48 PM <

Also tested in `dev-aws-us-east-1-integration-test` cluster.

<img width="1426" alt="Screen Shot 2022-10-21 at 6 02 31 PM" src="https://user-images.githubusercontent.com/96499497/197309554-5f2a8229-f50e-4ea5-b73e-755077af54a2.png">

