### PR TITLE
Fix attribution bug

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/attribution.go
+++ b/src/query/api/v1/handler/prometheus/remote/attribution.go
@@ -24,7 +24,7 @@ import (
 var errNoOption = errors.New("no option configured for promAttributionMetrics")
 var errInvalidMatcher = errors.New("invalid matcher configured for promAttributionMetrics")
 
-type matchOp int
+type matchOp uint8
 
 const (
 	Eq matchOp = iota // ==
@@ -37,12 +37,12 @@ type matcher struct {
 }
 
 func newMatcher(config string) (string, *matcher, error) {
-	eqRegexp := regexp.MustCompile(`(\w+)==(\w+)`)
+	eqRegexp := regexp.MustCompile(`(\w+)==(.*)`)
 	if eqRegexp.MatchString(config) {
 		groups := eqRegexp.FindStringSubmatch(config)
 		return groups[1], &matcher{op: Eq, pattern: groups[2]}, nil
 	}
-	neRegexp := regexp.MustCompile(`(\w+)!=(\w+)`)
+	neRegexp := regexp.MustCompile(`(\w+)!=(.*)`)
 	if neRegexp.MatchString(config) {
 		groups := neRegexp.FindStringSubmatch(config)
 		return groups[1], &matcher{op: Ne, pattern: groups[2]}, nil
@@ -136,9 +136,10 @@ func newPromAttributionMetrics(scope tally.Scope,
 			logger.Error("Encounter invalid matchers", zap.String("match", mCfg), zap.Error(err))
 			return nil, err
 		} else {
-			logger.Debug("Adding matcher to attribution group",
+			logger.Info("Adding matcher to attribution group",
 				zap.String("attribution", opts.Name),
 				zap.String("key", key),
+				zap.Uint8("op", uint8(m.op)),
 				zap.String("value", m.pattern))
 			matchers[key] = m
 		}

--- a/src/query/api/v1/handler/prometheus/remote/attribution.go
+++ b/src/query/api/v1/handler/prometheus/remote/attribution.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"errors"
 	"math/rand"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -10,6 +11,7 @@ import (
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 /**
@@ -20,11 +22,48 @@ import (
  */
 
 var errNoOption = errors.New("no option configured for promAttributionMetrics")
-var errInvalidFilter = errors.New("invalid filter configured for promAttributionMetrics, must be `label=value`")
+var errInvalidMatcher = errors.New("invalid matcher configured for promAttributionMetrics")
+
+type matchOp int
+
+const (
+	Eq matchOp = iota // ==
+	Ne                // !=
+)
+
+type matcher struct {
+	op      matchOp
+	pattern string
+}
+
+func newMatcher(config string) (string, *matcher, error) {
+	eqRegexp := regexp.MustCompile(`(\w+)==(\w+)`)
+	if eqRegexp.MatchString(config) {
+		groups := eqRegexp.FindStringSubmatch(config)
+		return groups[1], &matcher{op: Eq, pattern: groups[2]}, nil
+	}
+	neRegexp := regexp.MustCompile(`(\w+)!=(\w+)`)
+	if neRegexp.MatchString(config) {
+		groups := neRegexp.FindStringSubmatch(config)
+		return groups[1], &matcher{op: Ne, pattern: groups[2]}, nil
+	}
+	return "", nil, errInvalidMatcher
+}
+
+func (m *matcher) match(value string) bool {
+	switch m.op {
+	case Eq:
+		return m.pattern == value
+	case Ne:
+		return m.pattern != value
+	default:
+		return false
+	}
+}
 
 type promAttributionMetrics struct {
 	opts               *instrument.AttributionConfiguration
-	filters            map[string]string
+	matchers           map[string]*matcher
 	baseScope          tally.Scope
 	attributedCounters sync.Map
 	counterSize        int32
@@ -32,33 +71,32 @@ type promAttributionMetrics struct {
 	missSamples        tally.Counter
 }
 
-func (pam *promAttributionMetrics) filter(label prompb.Label) bool {
-	if pattern, ok := pam.filters[string(label.Name)]; ok {
-		if pattern == string(label.Value) {
-			return true
+func (pam *promAttributionMetrics) match(labels []prompb.Label) bool {
+	for _, l := range labels {
+		name := string(l.Name)
+		if m, ok := pam.matchers[name]; ok {
+			if !m.match(string(l.Value)) {
+				// if 1 of the matches violates, skip the attribution
+				return false
+			}
 		}
-		// TODO: support regex match
 	}
-	return false
+	return true
 }
 
 func (pam *promAttributionMetrics) attribute(ts prompb.TimeSeries) {
-	if rand.Float64() >= pam.opts.SamplingRate {
+	if rand.Float64() >= pam.opts.SamplingRate || !pam.match(ts.Labels) {
 		return
 	}
-	labelValues := make([]string, len(pam.opts.Labels))
+	matchedValues := make([]string, len(pam.opts.Labels))
 	found := 0
 	sample_count := int64(len(ts.Samples))
 	for _, l := range ts.Labels {
-		if pam.filter(l) {
-			// filter out samples not qualified for this attribution
-			return
-		}
 		labelName := string(l.Name)
 		for i, label := range pam.opts.Labels {
 			if labelName == label {
 				found++
-				labelValues[i] = string(l.Value)
+				matchedValues[i] = string(l.Value)
 			}
 		}
 	}
@@ -68,7 +106,7 @@ func (pam *promAttributionMetrics) attribute(ts prompb.TimeSeries) {
 		return
 	}
 	attributeLabels := strings.Join(pam.opts.Labels, "_")
-	attributeValues := strings.Join(labelValues, ":")
+	attributeValues := strings.Join(matchedValues, ":")
 	// look up if the counter in the map already, if not in the map and the counter reaches its capacity, consider this is a miss
 	_, ok := pam.attributedCounters.Load(attributeValues)
 	if !ok && pam.counterSize >= int32(pam.opts.Capacity) {
@@ -84,22 +122,30 @@ func (pam *promAttributionMetrics) attribute(ts prompb.TimeSeries) {
 	(c.(tally.Counter)).Inc(sample_count)
 }
 
-func newPromAttributionMetrics(scope tally.Scope, opts *instrument.AttributionConfiguration) (*promAttributionMetrics, error) {
+func newPromAttributionMetrics(scope tally.Scope,
+	opts *instrument.AttributionConfiguration,
+	logger *zap.Logger) (*promAttributionMetrics, error) {
 	if opts == nil {
 		return nil, errNoOption
 	}
+	logger.Info("Creating new attribution group", zap.String("name", opts.Name))
 	baseScope := scope.SubScope("attribution").SubScope(opts.Name)
-	filters := map[string]string{}
-	for _, filter := range opts.Filters {
-		parts := strings.Split(filter, "=")
-		if len(parts) != 2 {
-			return nil, errInvalidFilter
+	matchers := map[string]*matcher{}
+	for _, mCfg := range opts.Matchers {
+		if key, m, err := newMatcher(mCfg); err != nil {
+			logger.Error("Encounter invalid matchers", zap.String("match", mCfg), zap.Error(err))
+			return nil, err
+		} else {
+			logger.Debug("Adding matcher to attribution group",
+				zap.String("attribution", opts.Name),
+				zap.String("key", key),
+				zap.String("value", m.pattern))
+			matchers[key] = m
 		}
-		filters[parts[0]] = parts[1]
 	}
 	return &promAttributionMetrics{
 		opts:               opts,
-		filters:            filters,
+		matchers:           matchers,
 		baseScope:          baseScope,
 		attributedCounters: sync.Map{},
 		counterSize:        0,

--- a/src/query/api/v1/handler/prometheus/remote/attribution_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/attribution_test.go
@@ -31,7 +31,7 @@ func TestPromAttributionMetrics_SingleLabel(t *testing.T) {
 	}
 	pam.attribute(ts)
 	foundMetric := xclock.WaitUntil(func() bool {
-		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
+		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+attr_labelA=value-A,test=prom-attribution-test"]
 		return ok && found.Value() == 3
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -65,7 +65,7 @@ func TestPromAttributionMetrics_MultipleLabels(t *testing.T) {
 		pam.attribute(ts)
 	}
 	foundMetric := xclock.WaitUntil(func() bool {
-		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+labelA_labelB=value-A:valueB,test=prom-attribution-test"]
+		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+attr_labelA_labelB=value-A:valueB,test=prom-attribution-test"]
 		return ok && found.Value() == 7
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -101,8 +101,8 @@ func TestPromAttributionMetrics_Capacity(t *testing.T) {
 	// Because capacity is one, label A with multiple values will only have 1 counter, the other one should go to miss
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
-		found, ok := counters["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
-		_, notOk := counters["base.attribution.name.sample_count+labelA=value-A1,test=prom-attribution-test"]
+		found, ok := counters["base.attribution.name.sample_count+attr_labelA=value-A,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+attr_labelA=value-A1,test=prom-attribution-test"]
 		return ok && found.Value() == 10 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -143,8 +143,8 @@ func TestPromAttributionMetrics_EqMatch(t *testing.T) {
 	// samples that contain labelA with value-A will be used
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
-		found, ok := counters["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
-		_, notOk := counters["base.attribution.name.sample_count+labelA=value-A1,test=prom-attribution-test"]
+		found, ok := counters["base.attribution.name.sample_count+attr_labelA=value-A,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+attr_labelA=value-A1,test=prom-attribution-test"]
 		return ok && found.Value() == 10 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -185,8 +185,8 @@ func TestPromAttributionMetrics_NeMatch(t *testing.T) {
 	// samples that contain labelA without value-A will be used
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
-		found, ok := counters["base.attribution.name.sample_count+labelA=value-A1,test=prom-attribution-test"]
-		_, notOk := counters["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
+		found, ok := counters["base.attribution.name.sample_count+attr_labelA=value-A1,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+attr_labelA=value-A,test=prom-attribution-test"]
 		return ok && found.Value() == 13 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)

--- a/src/query/api/v1/handler/prometheus/remote/attribution_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/attribution_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/uber-go/tally"
 )
 
-var TEST_LABEL_A = prompb.Label{Name: []byte("labelA"), Value: []byte("valueA")}
+var TEST_LABEL_A = prompb.Label{Name: []byte("labelA"), Value: []byte("value-A")}
 var TEST_LABEL_B = prompb.Label{Name: []byte("labelB"), Value: []byte("valueB")}
-var TEST_LABEL_A1 = prompb.Label{Name: []byte("labelA"), Value: []byte("valueA1")}
+var TEST_LABEL_A1 = prompb.Label{Name: []byte("labelA"), Value: []byte("value-A1")}
 
 func TestPromAttributionMetrics_SingleLabel(t *testing.T) {
 	logger := instrument.NewTestDebugLogger(t)
@@ -31,7 +31,7 @@ func TestPromAttributionMetrics_SingleLabel(t *testing.T) {
 	}
 	pam.attribute(ts)
 	foundMetric := xclock.WaitUntil(func() bool {
-		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+labelA=valueA,test=prom-attribution-test"]
+		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
 		return ok && found.Value() == 3
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -65,7 +65,7 @@ func TestPromAttributionMetrics_MultipleLabels(t *testing.T) {
 		pam.attribute(ts)
 	}
 	foundMetric := xclock.WaitUntil(func() bool {
-		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+labelA_labelB=valueA:valueB,test=prom-attribution-test"]
+		found, ok := scope.Snapshot().Counters()["base.attribution.name.sample_count+labelA_labelB=value-A:valueB,test=prom-attribution-test"]
 		return ok && found.Value() == 7
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -101,8 +101,8 @@ func TestPromAttributionMetrics_Capacity(t *testing.T) {
 	// Because capacity is one, label A with multiple values will only have 1 counter, the other one should go to miss
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
-		found, ok := counters["base.attribution.name.sample_count+labelA=valueA,test=prom-attribution-test"]
-		_, notOk := counters["base.attribution.name.sample_count+labelA=valueA1,test=prom-attribution-test"]
+		found, ok := counters["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+labelA=value-A1,test=prom-attribution-test"]
 		return ok && found.Value() == 10 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -116,7 +116,7 @@ func TestPromAttributionMetrics_EqMatch(t *testing.T) {
 		Capacity:     10,
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name)},
-		Matchers:     []string{"labelA==valueA"},
+		Matchers:     []string{"labelA==value-A"},
 	}
 	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
 	tsList := []prompb.TimeSeries{
@@ -140,11 +140,11 @@ func TestPromAttributionMetrics_EqMatch(t *testing.T) {
 	for _, ts := range tsList {
 		pam.attribute(ts)
 	}
-	// samples that contain labelA with valueA will be used
+	// samples that contain labelA with value-A will be used
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
-		found, ok := counters["base.attribution.name.sample_count+labelA=valueA,test=prom-attribution-test"]
-		_, notOk := counters["base.attribution.name.sample_count+labelA=valueA1,test=prom-attribution-test"]
+		found, ok := counters["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+labelA=value-A1,test=prom-attribution-test"]
 		return ok && found.Value() == 10 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -158,7 +158,7 @@ func TestPromAttributionMetrics_NeMatch(t *testing.T) {
 		Capacity:     10,
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name)},
-		Matchers:     []string{"labelA!=valueA"},
+		Matchers:     []string{"labelA!=value-A"},
 	}
 	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
 	tsList := []prompb.TimeSeries{
@@ -182,11 +182,11 @@ func TestPromAttributionMetrics_NeMatch(t *testing.T) {
 	for _, ts := range tsList {
 		pam.attribute(ts)
 	}
-	// samples that contain labelA without valueA will be used
+	// samples that contain labelA without value-A will be used
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
-		found, ok := counters["base.attribution.name.sample_count+labelA=valueA1,test=prom-attribution-test"]
-		_, notOk := counters["base.attribution.name.sample_count+labelA=valueA,test=prom-attribution-test"]
+		found, ok := counters["base.attribution.name.sample_count+labelA=value-A1,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+labelA=value-A,test=prom-attribution-test"]
 		return ok && found.Value() == 13 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -200,7 +200,7 @@ func TestPromAttributionMetrics_InvalidMatcher(t *testing.T) {
 		Capacity:     10,
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name)},
-		Matchers:     []string{"labe_lA=~valueA"},
+		Matchers:     []string{"labe_lA=~value-A"},
 	}
 	pam, err := newPromAttributionMetrics(scope, &opts, logger)
 	require.Nil(t, pam)

--- a/src/query/api/v1/handler/prometheus/remote/attribution_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/attribution_test.go
@@ -16,6 +16,7 @@ var TEST_LABEL_B = prompb.Label{Name: []byte("labelB"), Value: []byte("valueB")}
 var TEST_LABEL_A1 = prompb.Label{Name: []byte("labelA"), Value: []byte("valueA1")}
 
 func TestPromAttributionMetrics_SingleLabel(t *testing.T) {
+	logger := instrument.NewTestDebugLogger(t)
 	scope := tally.NewTestScope("base", map[string]string{"test": "prom-attribution-test"})
 	opts := instrument.AttributionConfiguration{
 		Name:         "name",
@@ -23,7 +24,7 @@ func TestPromAttributionMetrics_SingleLabel(t *testing.T) {
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name)},
 	}
-	pam, _ := newPromAttributionMetrics(scope, &opts)
+	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
 	ts := prompb.TimeSeries{
 		Labels:  []prompb.Label{TEST_LABEL_A},
 		Samples: make([]prompb.Sample, 3),
@@ -37,6 +38,7 @@ func TestPromAttributionMetrics_SingleLabel(t *testing.T) {
 }
 
 func TestPromAttributionMetrics_MultipleLabels(t *testing.T) {
+	logger := instrument.NewTestDebugLogger(t)
 	scope := tally.NewTestScope("base", map[string]string{"test": "prom-attribution-test"})
 	opts := instrument.AttributionConfiguration{
 		Name:         "name",
@@ -44,7 +46,7 @@ func TestPromAttributionMetrics_MultipleLabels(t *testing.T) {
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name), string(TEST_LABEL_B.Name)},
 	}
-	pam, _ := newPromAttributionMetrics(scope, &opts)
+	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
 	tsList := []prompb.TimeSeries{
 		{
 			Labels:  []prompb.Label{TEST_LABEL_A},
@@ -70,6 +72,7 @@ func TestPromAttributionMetrics_MultipleLabels(t *testing.T) {
 }
 
 func TestPromAttributionMetrics_Capacity(t *testing.T) {
+	logger := instrument.NewTestDebugLogger(t)
 	scope := tally.NewTestScope("base", map[string]string{"test": "prom-attribution-test"})
 	opts := instrument.AttributionConfiguration{
 		Name:         "name",
@@ -77,7 +80,7 @@ func TestPromAttributionMetrics_Capacity(t *testing.T) {
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name)},
 	}
-	pam, _ := newPromAttributionMetrics(scope, &opts)
+	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
 	tsList := []prompb.TimeSeries{
 		{
 			Labels:  []prompb.Label{TEST_LABEL_A},
@@ -105,16 +108,17 @@ func TestPromAttributionMetrics_Capacity(t *testing.T) {
 	require.True(t, foundMetric)
 }
 
-func TestPromAttributionMetrics_Filters(t *testing.T) {
+func TestPromAttributionMetrics_EqMatch(t *testing.T) {
+	logger := instrument.NewTestDebugLogger(t)
 	scope := tally.NewTestScope("base", map[string]string{"test": "prom-attribution-test"})
 	opts := instrument.AttributionConfiguration{
 		Name:         "name",
 		Capacity:     10,
 		SamplingRate: 1,
 		Labels:       []string{string(TEST_LABEL_A.Name)},
-		Filters:      []string{"labelA=valueA"},
+		Matchers:     []string{"labelA==valueA"},
 	}
-	pam, _ := newPromAttributionMetrics(scope, &opts)
+	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
 	tsList := []prompb.TimeSeries{
 		{
 			Labels:  []prompb.Label{TEST_LABEL_A},
@@ -136,7 +140,49 @@ func TestPromAttributionMetrics_Filters(t *testing.T) {
 	for _, ts := range tsList {
 		pam.attribute(ts)
 	}
-	// samples that contain labelA=valueA will be filtered, only labelA=valueA1 will be counted
+	// samples that contain labelA with valueA will be used
+	foundMetric := xclock.WaitUntil(func() bool {
+		counters := scope.Snapshot().Counters()
+		found, ok := counters["base.attribution.name.sample_count+labelA=valueA,test=prom-attribution-test"]
+		_, notOk := counters["base.attribution.name.sample_count+labelA=valueA1,test=prom-attribution-test"]
+		return ok && found.Value() == 10 && !notOk
+	}, 5*time.Second)
+	require.True(t, foundMetric)
+}
+
+func TestPromAttributionMetrics_NeMatch(t *testing.T) {
+	logger := instrument.NewTestDebugLogger(t)
+	scope := tally.NewTestScope("base", map[string]string{"test": "prom-attribution-test"})
+	opts := instrument.AttributionConfiguration{
+		Name:         "name",
+		Capacity:     10,
+		SamplingRate: 1,
+		Labels:       []string{string(TEST_LABEL_A.Name)},
+		Matchers:     []string{"labelA!=valueA"},
+	}
+	pam, _ := newPromAttributionMetrics(scope, &opts, logger)
+	tsList := []prompb.TimeSeries{
+		{
+			Labels:  []prompb.Label{TEST_LABEL_A},
+			Samples: make([]prompb.Sample, 3),
+		},
+		{
+			Labels:  []prompb.Label{TEST_LABEL_A1},
+			Samples: make([]prompb.Sample, 2),
+		},
+		{
+			Labels:  []prompb.Label{TEST_LABEL_B, TEST_LABEL_A},
+			Samples: make([]prompb.Sample, 7),
+		},
+		{
+			Labels:  []prompb.Label{TEST_LABEL_B, TEST_LABEL_A1},
+			Samples: make([]prompb.Sample, 11),
+		},
+	}
+	for _, ts := range tsList {
+		pam.attribute(ts)
+	}
+	// samples that contain labelA without valueA will be used
 	foundMetric := xclock.WaitUntil(func() bool {
 		counters := scope.Snapshot().Counters()
 		found, ok := counters["base.attribution.name.sample_count+labelA=valueA1,test=prom-attribution-test"]
@@ -144,4 +190,19 @@ func TestPromAttributionMetrics_Filters(t *testing.T) {
 		return ok && found.Value() == 13 && !notOk
 	}, 5*time.Second)
 	require.True(t, foundMetric)
+}
+
+func TestPromAttributionMetrics_InvalidMatcher(t *testing.T) {
+	logger := instrument.NewTestDebugLogger(t)
+	scope := tally.NewTestScope("base", map[string]string{"test": "prom-attribution-test"})
+	opts := instrument.AttributionConfiguration{
+		Name:         "name",
+		Capacity:     10,
+		SamplingRate: 1,
+		Labels:       []string{string(TEST_LABEL_A.Name)},
+		Matchers:     []string{"labe_lA=~valueA"},
+	}
+	pam, err := newPromAttributionMetrics(scope, &opts, logger)
+	require.Nil(t, pam)
+	require.Equal(t, errInvalidMatcher, err)
 }

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -141,6 +141,7 @@ func NewPromWriteHandler(options options.HandlerOptions) (http.Handler, error) {
 		nowFn                = options.NowFn()
 		forwarding           = options.Config().WriteForwarding.PromRemoteWrite
 		instrumentOpts       = options.InstrumentOpts()
+		logger               = instrumentOpts.Logger()
 	)
 
 	if downsamplerAndWriter == nil {
@@ -165,7 +166,7 @@ func NewPromWriteHandler(options options.HandlerOptions) (http.Handler, error) {
 
 	attributions := make([]*promAttributionMetrics, len(options.Config().Metrics.Attributions))
 	for i, attributionOpts := range options.Config().Metrics.Attributions {
-		attribution, _ := newPromAttributionMetrics(scope, attributionOpts)
+		attribution, _ := newPromAttributionMetrics(scope, attributionOpts, logger)
 		attributions[i] = attribution
 	}
 

--- a/src/x/instrument/config.go
+++ b/src/x/instrument/config.go
@@ -62,7 +62,7 @@ type AttributionConfiguration struct {
 
 	// Matched labels of this attribution, if a time series has label A & B & C, and here we attribute
 	// to A, we will count all ts with coordinator_attribution_A_sample_count{A="value for label A"}
-	Labels []string `yaml:"labels"`
+	Labels []string `yaml:"labels" validate:"min=1,max=3"`
 
 	// Match metrics for attribution, we support two types of matchers for now:
 	// 1. only sample with label A == <value> will be used for attribution

--- a/src/x/instrument/config.go
+++ b/src/x/instrument/config.go
@@ -60,11 +60,15 @@ type AttributionConfiguration struct {
 	// Sampling rate
 	SamplingRate float64 `yaml:"samplingRate" validate:"nonzero,min=0.0,max=1.0"`
 
-	// Matched labels of this attribution
+	// Matched labels of this attribution, if a time series has label A & B & C, and here we attribute
+	// to A, we will count all ts with coordinator_attribution_A_sample_count{A="value for label A"}
 	Labels []string `yaml:"labels"`
 
-	// Filter metrics for attribution
-	Filters []string `yaml:"filters"`
+	// Match metrics for attribution, we support two types of matchers for now:
+	// 1. only sample with label A == <value> will be used for attribution
+	// 2. only sample with label A != <value> will be used for attribution
+	// the final decision is concatenated using AND unary among matchers
+	Matchers []string `yaml:"matchers"`
 }
 
 // MetricsConfiguration configures options for emitting metrics.


### PR DESCRIPTION
* Previously we use the term filters which should do attribution for samples when filters = true, but it was the other way, fix this bug
* Also change the config name from `filters` to `matchers` for simpler to understand its purpose.
* Add more comments to `AttributionConfiguration`
* Add more unit tests

== commit https://github.com/databricks/m3/pull/23/commits/581bcb04a75379bd969d0e60551e112dbed8ccf7 ===
* Enforce configuration to have at most 3 labels
* Add prefix for attribution key to avoid label conflicts like "job" vs "exported_job"

=== Tests ===
Run unit tests it passes:
/usr/local/bin/go test -timeout 30s -run '^TestPromAttributionMetrics_.*$' github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote

Also using https://github.com/databricks/universe/pull/225798 to verify the change works properly