### PR TITLE
[PLAT-69100] A config validation run mode for m3coord binary

### DIFF
--- a/src/cmd/services/m3coordinator/main/main.go
+++ b/src/cmd/services/m3coordinator/main/main.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"log"
 
+	"github.com/m3db/m3/src/cmd/services/m3coordinator/downsample"
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/query/server"
 	xconfig "github.com/m3db/m3/src/x/config"
@@ -40,6 +41,14 @@ func main() {
 	if err := cfgOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
 		log.Fatalf("error loading config: %v", err)
 	}
+
+  if cfgOpts.ShouldValidateConfigAndExit && cfg.Downsample.Rules != nil {
+    if err := downsample.ValidateAggregationRules(*cfg.Downsample.Rules); err != nil {
+		  log.Fatalf("error validating config: %v", err)
+    }
+    log.Print("the config is valid.")
+    return
+  }
 
 	server.Run(server.RunOptions{
 		Config: cfg,

--- a/src/x/config/configflag/flag.go
+++ b/src/x/config/configflag/flag.go
@@ -42,6 +42,10 @@ type Options struct {
 	// and then exit.
 	ShouldDumpConfigAndExit bool
 
+	// ShouldValidateConfigAndExit (-z) causes MainLoad to validate the config
+	// and return an error if the config is invalid.
+	ShouldValidateConfigAndExit bool
+
 	// for Usage()
 	cmd *flag.FlagSet
 
@@ -60,6 +64,7 @@ func (opts *Options) RegisterFlagSet(cmd *flag.FlagSet) {
 
 	cmd.Var(&opts.ConfigFiles, "f", "Configuration files to load")
 	cmd.BoolVar(&opts.ShouldDumpConfigAndExit, "d", false, "Dump configuration and exit")
+	cmd.BoolVar(&opts.ShouldValidateConfigAndExit, "z", false, "Validate configuration and exit")
 }
 
 // MainLoad is a convenience method, intended for use in main(), which handles all


### PR DESCRIPTION
```
# Test duplicate rule detection

$ bin/m3coordinator -f ~/data/m3coord.yaml -z
2022/11/29 09:48:28 Go Runtime version: go1.19.2
2022/11/29 09:48:28 Build Version:      v1.5.0
2022/11/29 09:48:28 Build Revision:     0421f02e9
2022/11/29 09:48:28 Build Branch:       PLAT-69100.validate-write-coord-config
2022/11/29 09:48:28 Build Date:         2022-11-28-22:00:13
2022/11/29 09:48:28 Build TimeUnix:     1669701613
2022/11/29 09:48:28 error validating config: Error from adding rollup rule [rollupRules: __name__:rpc_client_request_duration_seconds_count kubernetes_namespace:*]: cannot revive rule rollupRules: __name__:rpc_client_request_duration_seconds_count kubernetes_namespace:*: rollupRules: __name__:rpc_client_request_duration_seconds_count kubernetes_namespace:* is not tombstoned

# Test extra wildcards
# - "filter": "__name__:rpc_*client_request_*duration_seconds_count kubernetes_namespace:*"
$ bin/m3coordinator -f ~/data/m3coord.yaml -z
2022/11/29 09:52:03 Go Runtime version: go1.19.2
2022/11/29 09:52:03 Build Version:      v1.5.0
2022/11/29 09:52:03 Build Revision:     0421f02e9
2022/11/29 09:52:03 Build Branch:       PLAT-69100.validate-write-coord-config
2022/11/29 09:52:03 Build Date:         2022-11-28-22:00:13
2022/11/29 09:52:03 Build TimeUnix:     1669701613
2022/11/29 09:52:03 error validating config: Error from adding rollup rule [rollupRules: __name__:rpc_client_request_duration_seconds_count kubernetes_namespace:*]: cannot add rule rollupRules: __name__:rpc_client_request_duration_seconds_count kubernetes_namespace:*: tags filter __name__:rpc_*client_request_*duration_seconds_count kubernetes_namespace:* contains invalid filter pattern rpc_*client_request_*duration_seconds_count for tag __name__: invalid filter pattern defined

# Test invalid transform
$ bin/m3coordinator -f ~/data/m3coord.yaml -z
2022/11/29 09:55:05 Go Runtime version: go1.19.2
2022/11/29 09:55:05 Build Version:      v1.5.0
2022/11/29 09:55:05 Build Revision:     0421f02e9
2022/11/29 09:55:05 Build Branch:       PLAT-69100.validate-write-coord-config
2022/11/29 09:55:05 Build Date:         2022-11-28-22:00:13
2022/11/29 09:55:05 Build TimeUnix:     1669701613
2022/11/29 09:55:05 error loading config: unable to load config from [/Users/hc.zhu/data/m3coord.yaml]: invalid transformation type: Decrease

# Test good config
$ bin/m3coordinator -f ~/data/m3coord.yaml -z
2022/11/29 09:55:40 Go Runtime version: go1.19.2
2022/11/29 09:55:40 Build Version:      v1.5.0
2022/11/29 09:55:40 Build Revision:     0421f02e9
2022/11/29 09:55:40 Build Branch:       PLAT-69100.validate-write-coord-config
2022/11/29 09:55:40 Build Date:         2022-11-28-22:00:13
2022/11/29 09:55:40 Build TimeUnix:     1669701613
2022/11/29 09:55:40 the config is valid.


```