### PR TITLE
[PLAT-73030] Verify wildcard filter won't match metric without the label

### DIFF
--- a/src/metrics/filters/tags_filter_test.go
+++ b/src/metrics/filters/tags_filter_test.go
@@ -88,6 +88,26 @@ func TestEmptyTagsFilterMatches(t *testing.T) {
 	require.True(t, matches)
 }
 
+func TestNonexistTagsFilterMatches(t *testing.T) {
+	filters := map[string]FilterValue{
+		"tagName1": FilterValue{Pattern: "tagValue1"},
+		"tagName2": FilterValue{Pattern: "*"},
+	}
+	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
+	inputs := []mockFilterData{
+		{val: "tagName1=tagValue1,tagName2=abc", match: true},
+		{val: "tagName1=tagValue1", match: false},
+		{val: "tagName1=oooo,tagName2=tagValue2", match: false},
+		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3", match: true},
+	}
+	require.NoError(t, err)
+	for _, input := range inputs {
+		matches, err := f.Matches([]byte(input.val), testTagsMatchOptions())
+		require.NoError(t, err)
+		require.Equal(t, input.match, matches)
+	}
+}
+
 func TestTagsFilterMatchesNoNameTag(t *testing.T) {
 	filters := map[string]FilterValue{
 		"tagName1": FilterValue{Pattern: "tagValue1"},


### PR DESCRIPTION
## How did we test
Ran the added unit test and verified it won't match metrics without the label for wildcard

```
~/repos/m3 (filter-tests) $ go test -run '.*TestNonexistTagsFilterMatches.*' github.com/m3db/m3/src/metrics/filters
ok  	github.com/m3db/m3/src/metrics/filters	1.080s
```

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
