### PR TITLE
[PLAT-77859 ] Export gauges for top metrics in m3db

### DIFF
--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -495,6 +495,16 @@ type TickConfiguration struct {
 
 	// Tick minimum interval controls the minimum tick interval for the node.
 	MinimumInterval time.Duration `yaml:"minimumInterval"`
+
+	// Track top N metrics in terms of cardinality and export gauge metrics for top metrics.
+	// <= 0 means no tracking.
+	TopMetricsToTrack       int `yaml:"topMetricsToTrack"`
+	// Only track metrics with cardinality >= minCardinality.
+	MinCardinalityToTrack   int `yaml:"minCardinalityToTrack" validate:"min=10"`
+	// Cap the size of the map of metric names to cardinality to maxMapLen to avoid unbounded memory usage.
+	MaxMapLenForTracking    int `yaml:"maxMapLenForTracking" validate:"min=10"`
+	// How often to report the top metrics? Once in every N ticks.
+	TopMetricsTrackingTicks int `yaml:"topMetricsTrackingTicks" validate:"min=1"`
 }
 
 // BlockRetrievePolicy is the block retrieve policy.

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -80,7 +80,7 @@ import (
 
 var (
 	id                  = flag.String("id", "", "Node host ID")
-	httpClusterAddr     = flag.String("clusterhttpaddr", "127.0.0.1:9000", "Cluster HTTP server address")
+	httpClusterAddr     = flag.String("clusterhttpaddr", "127.0.0.1:9005", "Cluster HTTP server address")
 	tchannelClusterAddr = flag.String("clustertchanneladdr", "127.0.0.1:9001", "Cluster TChannel server address")
 	httpNodeAddr        = flag.String("nodehttpaddr", "127.0.0.1:9002", "Node HTTP server address")
 	tchannelNodeAddr    = flag.String("nodetchanneladdr", "127.0.0.1:9003", "Node TChannel server address")

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -582,9 +582,27 @@ func Run(runOpts RunOptions) {
 
 	if tick := cfg.Tick; tick != nil {
 		runtimeOpts = runtimeOpts.
-			SetTickSeriesBatchSize(tick.SeriesBatchSize).
-			SetTickPerSeriesSleepDuration(tick.PerSeriesSleepDuration).
 			SetTickMinimumInterval(tick.MinimumInterval)
+		if tick.SeriesBatchSize > 0 {
+			runtimeOpts = runtimeOpts.SetTickSeriesBatchSize(tick.SeriesBatchSize)
+			logger.Info("Setting up tick configuration: ", zap.Int("SeriesBatchSize", tick.SeriesBatchSize))
+		}
+		if tick.PerSeriesSleepDuration > 0 {
+			logger.Info("Setting up tick configuration: ", zap.Duration("PerSeriesSleepDuration", tick.PerSeriesSleepDuration))
+		}
+
+		logger.Info("Setting up tick configuration",
+			zap.Int("TopMetricsToTrack", tick.TopMetricsToTrack),
+			zap.Int("TopMetricsTrackingTicks", tick.TopMetricsTrackingTicks),
+		)
+		opts = opts.SetTickOptions(
+			storage.TickOptions{
+				TopMetricsToTrack:       tick.TopMetricsToTrack,
+				MinCardinalityToTrack:   tick.MinCardinalityToTrack,
+				MaxMapLenForTracking:    tick.MaxMapLenForTracking,
+				TopMetricsTrackingTicks: tick.TopMetricsTrackingTicks,
+			},
+		)
 	}
 
 	runtimeOptsMgr := m3dbruntime.NewOptionsManager()

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -145,7 +145,10 @@ type dbNamespace struct {
 	tickWorkersConcurrency int
 	statsLastTick          databaseNamespaceStatsLastTick
 
-	metrics databaseNamespaceMetrics
+	metrics               databaseNamespaceMetrics
+	tickOptions           TickOptions
+	tickSeqNo             int64 // The sequence number of the current tick.
+	shouldTrackTopMetrics bool
 }
 
 type databaseNamespaceStatsLastTick struct {
@@ -201,6 +204,7 @@ type databaseNamespaceShardMetrics struct {
 
 type databaseNamespaceTickMetrics struct {
 	activeSeries           tally.Gauge
+	metricCardinality      tally.Scope // holds multiple gauges.
 	expiredSeries          tally.Counter
 	activeBlocks           tally.Gauge
 	wiredBlocks            tally.Gauge
@@ -212,6 +216,9 @@ type databaseNamespaceTickMetrics struct {
 	errors                 tally.Counter
 	index                  databaseNamespaceIndexTickMetrics
 	evictedBuckets         tally.Counter
+    // How many nanoseconds for running a metric tracking tick.
+	tickDuration     tally.Timer
+	tickRuns         tally.Counter
 }
 
 type databaseNamespaceIndexTickMetrics struct {
@@ -277,6 +284,7 @@ func newDatabaseNamespaceMetrics(
 		},
 		tick: databaseNamespaceTickMetrics{
 			activeSeries:           tickScope.Gauge("active-series"),
+			metricCardinality:      tickScope.SubScope("top_metric_"), // "top_metric__xyz" for metric "xyz"
 			expiredSeries:          tickScope.Counter("expired-series"),
 			activeBlocks:           tickScope.Gauge("active-blocks"),
 			wiredBlocks:            tickScope.Gauge("wired-blocks"),
@@ -294,6 +302,8 @@ func newDatabaseNamespaceMetrics(
 				numBlocksEvicted: indexTickScope.Counter("num-blocks-evicted"),
 			},
 			evictedBuckets: tickScope.Counter("evicted-buckets"),
+			tickDuration:    tickScope.Timer("namespace-duration"),
+			tickRuns:        tickScope.Counter("runs"),
 		},
 		status: databaseNamespaceStatusMetrics{
 			activeSeries: statusScope.Gauge("active-series"),
@@ -385,6 +395,9 @@ func newDatabaseNamespace(
 		tickWorkers:            tickWorkers,
 		tickWorkersConcurrency: tickWorkersConcurrency,
 		metrics:                newDatabaseNamespaceMetrics(scope, iops.TimerOptions()),
+		tickOptions:            opts.TickOptions(),
+		tickSeqNo:              0,
+		shouldTrackTopMetrics:  opts.TickOptions().TopMetricsToTrack > 0 && opts.TickOptions().MaxMapLenForTracking > 0 && opts.TickOptions().TopMetricsTrackingTicks > 0,
 	}
 
 	n.createEmptyWarmIndexIfNotExistsFn = n.createEmptyWarmIndexIfNotExists
@@ -626,11 +639,22 @@ func (n *dbNamespace) Tick(c context.Cancellable, startTime xtime.UnixNano) erro
 
 	// Tick through the shards at a capped level of concurrency.
 	var (
-		r        tickResult
-		multiErr xerrors.MultiError
-		l        sync.Mutex
-		wg       sync.WaitGroup
+		r           tickResult
+		multiErr    xerrors.MultiError
+		l           sync.Mutex
+		wg          sync.WaitGroup
+		tickOptions = TickOptions{TopMetricsToTrack: 0}
 	)
+	n.tickSeqNo++
+	tickStartTimeNano := xtime.Now()
+	if n.shouldTrackTopMetrics && (n.tickSeqNo%int64(n.tickOptions.TopMetricsTrackingTicks) == 0) {
+		tickOptions = n.tickOptions
+		r.trackTopMetrics()
+		n.log.Info("Will track top metrics for this tick.",
+			zap.Int("TopMetricsTrackingTicks", n.tickOptions.TopMetricsTrackingTicks),
+			zap.Int64("tickSeqNo", n.tickSeqNo),
+		)
+	}
 	for _, shard := range shards {
 		shard := shard
 		wg.Add(1)
@@ -640,11 +664,10 @@ func (n *dbNamespace) Tick(c context.Cancellable, startTime xtime.UnixNano) erro
 			if c.IsCancelled() {
 				return
 			}
-
-			shardResult, err := shard.Tick(c, startTime, nsCtx)
+			shardResult, err := shard.Tick(c, startTime, nsCtx, tickOptions)
 
 			l.Lock()
-			r = r.merge(shardResult)
+			r.merge(shardResult, tickOptions.TopMetricsToTrack)
 			multiErr = multiErr.Add(err)
 			l.Unlock()
 		})
@@ -667,6 +690,7 @@ func (n *dbNamespace) Tick(c context.Cancellable, startTime xtime.UnixNano) erro
 	// NB: we early terminate here to ensure we are not reporting metrics
 	// based on in-accurate/partial tick results.
 	if err := multiErr.FinalError(); err != nil || c.IsCancelled() {
+		n.log.Debug("tick cancelled", zap.Error(err))
 		return err
 	}
 
@@ -696,6 +720,15 @@ func (n *dbNamespace) Tick(c context.Cancellable, startTime xtime.UnixNano) erro
 	n.metrics.tick.index.numBlocksEvicted.Inc(indexTickResults.NumBlocksEvicted)
 	n.metrics.tick.index.numBlocksSealed.Inc(indexTickResults.NumBlocksSealed)
 	n.metrics.tick.errors.Inc(int64(r.errors))
+	n.metrics.tick.tickRuns.Inc(1)
+
+	for _, metric := range r.metricToCardinality {
+		if metric.cardinality >= tickOptions.MinCardinalityToTrack {
+			// If the gauge does not exist, it will be created on the fly.
+			n.metrics.tick.metricCardinality.Gauge(string(metric.name)).Update(float64(metric.cardinality))
+		}
+	}
+	n.metrics.tick.tickDuration.Record(xtime.Since(tickStartTimeNano))
 
 	return nil
 }

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -176,6 +176,7 @@ type options struct {
 	permitsOptions                  permits.Options
 	limitsOptions                   limits.Options
 	coreFn                          xsync.CoreFn
+	tickOptions                     TickOptions
 }
 
 // NewOptions creates a new set of storage options with defaults.
@@ -932,6 +933,16 @@ func (o *options) SetCoreFn(value xsync.CoreFn) Options {
 	opts := *o
 	opts.coreFn = value
 	return &opts
+}
+
+func (o *options) SetTickOptions(value TickOptions) Options {
+	opts := *o
+	opts.tickOptions = value
+	return &opts
+}
+
+func (o *options) TickOptions() TickOptions {
+	return o.tickOptions
 }
 
 type noOpColdFlush struct{}

--- a/src/dbnode/storage/result_test.go
+++ b/src/dbnode/storage/result_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 Databricks, Inc.
+//
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	var a, b tickResult
+	a.metricToCardinality = map[uint64]*metricCardinality{
+		0: {name: []byte("a"), cardinality: 1},
+		1: {name: []byte("b"), cardinality: 101},
+	}
+	b.metricToCardinality = map[uint64]*metricCardinality{
+		1: {name: []byte("b"), cardinality: 1000},
+		2: {name: []byte("c"), cardinality: 101},
+	}
+	a.merge(b, 3)
+	require.Equal(t, 3, len(a.metricToCardinality))
+	require.Equal(t, 2, len(b.metricToCardinality))
+	require.Equal(t, 1, a.metricToCardinality[0].cardinality)
+	require.Equal(t, 1101, a.metricToCardinality[1].cardinality)
+	require.Equal(t, 101, a.metricToCardinality[2].cardinality)
+
+	a.metricToCardinality = map[uint64]*metricCardinality{
+		0: {name: []byte("a"), cardinality: 1},
+		1: {name: []byte("b"), cardinality: 101},
+	}
+	require.Equal(t, 2, len(a.metricToCardinality))
+	a.merge(b, 2)
+	require.Equal(t, 2, len(a.metricToCardinality))
+	require.Equal(t, 1101, a.metricToCardinality[1].cardinality)
+	require.Equal(t, 101, a.metricToCardinality[2].cardinality)
+}

--- a/src/dbnode/storage/shard_race_prop_test.go
+++ b/src/dbnode/storage/shard_race_prop_test.go
@@ -82,7 +82,7 @@ func testShardTickReadFnRace(t *testing.T, ids []ident.ID, tickBatchSize int, fn
 
 	wg.Add(2)
 	go func() {
-		_, err := shard.Tick(context.NewNoOpCanncellable(), xtime.Now(), namespace.Context{})
+		_, err := shard.Tick(context.NewNoOpCanncellable(), xtime.Now(), namespace.Context{}, TickOptions{})
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -205,7 +205,7 @@ func testShardTickWriteRace(t *testing.T, tickBatchSize, numSeries int) {
 	go func() {
 		defer doneFn()
 		<-barrier
-		_, err := shard.Tick(context.NewNoOpCanncellable(), xtime.Now(), namespace.Context{})
+		_, err := shard.Tick(context.NewNoOpCanncellable(), xtime.Now(), namespace.Context{}, TickOptions{})
 		assert.NoError(t, err)
 	}()
 
@@ -303,7 +303,7 @@ func TestShardTickBootstrapWriteRace(t *testing.T) {
 	go func() {
 		defer doneFn()
 		<-barrier
-		_, err := shard.Tick(context.NewNoOpCanncellable(), xtime.Now(), namespace.Context{})
+		_, err := shard.Tick(context.NewNoOpCanncellable(), xtime.Now(), namespace.Context{}, TickOptions{})
 		assert.NoError(t, err)
 	}()
 

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2290,7 +2290,7 @@ func (mr *MockdatabaseShardMockRecorder) Snapshot(blockStart, snapshotStart, flu
 }
 
 // Tick mocks base method.
-func (m *MockdatabaseShard) Tick(c context.Cancellable, startTime time0.UnixNano, nsCtx namespace.Context) (tickResult, error) {
+func (m *MockdatabaseShard) Tick(c context.Cancellable, startTime time0.UnixNano, nsCtx namespace.Context, tickOptions TickOptions) (tickResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tick", c, startTime, nsCtx)
 	ret0, _ := ret[0].(tickResult)
@@ -3868,6 +3868,15 @@ func NewMockOptions(ctrl *gomock.Controller) *MockOptions {
 	mock.recorder = &MockOptionsMockRecorder{mock}
 	return mock
 }
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOptions) SetTickOptions(TickOptions) Options {
+	return m
+}
+func (m *MockOptions) TickOptions() TickOptions {
+	return TickOptions{}
+}
+
 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOptions) EXPECT() *MockOptionsMockRecorder {

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -479,7 +479,7 @@ type databaseShard interface {
 	OnEvictedFromWiredList(id ident.ID, blockStart xtime.UnixNano)
 
 	// Tick performs all async updates
-	Tick(c context.Cancellable, startTime xtime.UnixNano, nsCtx namespace.Context) (tickResult, error)
+	Tick(c context.Cancellable, startTime xtime.UnixNano, nsCtx namespace.Context, tickOptions TickOptions) (tickResult, error)
 
 	// Write writes a value to the shard for an ID.
 	Write(
@@ -1010,6 +1010,13 @@ type OnColdFlushNamespace interface {
 // OptionTransform transforms given Options.
 type OptionTransform func(Options) Options
 
+type TickOptions struct {
+	TopMetricsToTrack       int
+	MinCardinalityToTrack   int
+	MaxMapLenForTracking    int
+	TopMetricsTrackingTicks int
+}
+
 // Options represents the options for storage.
 type Options interface {
 	// Validate validates assumptions baked into the code.
@@ -1344,6 +1351,9 @@ type Options interface {
 
 	// SetCoreFn sets the function for determining the current core.
 	SetCoreFn(value xsync.CoreFn) Options
+
+	SetTickOptions(value TickOptions) Options
+	TickOptions() TickOptions
 }
 
 // MemoryTracker tracks memory.


### PR DESCRIPTION
## Tests
### Storage package unit tests

I'm not going to add new unit tests, because we are close to abandoning m3 TSDB.

```
$ go test github.com/m3db/m3/src/dbnode/storage

?   	github.com/m3db/m3/src/dbnode/encoding/testgen	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/mocks	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/proto	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/proto/annotation	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/proto/index	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/proto/namespace	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/proto/pagetoken	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/proto/snapshot	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/thrift	[no test files]
?   	github.com/m3db/m3/src/dbnode/generated/thrift/rpc	[no test files]
?   	github.com/m3db/m3/src/dbnode/integration/fake	[no test files]
?   	github.com/m3db/m3/src/dbnode/integration/generate	[no test files]
?   	github.com/m3db/m3/src/dbnode/kvconfig	[no test files]
?   	github.com/m3db/m3/src/dbnode/network/server	[no test files]
?   	github.com/m3db/m3/src/dbnode/network/server/httpjson/cluster	[no test files]
?   	github.com/m3db/m3/src/dbnode/network/server/httpjson/node	[no test files]
?   	github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/node/channel	[no test files]
?   	github.com/m3db/m3/src/dbnode/persist	[no test files]
?   	github.com/m3db/m3/src/dbnode/ratelimit	[no test files]
ok  	github.com/m3db/m3/src/dbnode/client	10.378s
ok  	github.com/m3db/m3/src/dbnode/digest	0.837s
ok  	github.com/m3db/m3/src/dbnode/discovery	0.836s
ok  	github.com/m3db/m3/src/dbnode/encoding	0.570s
ok  	github.com/m3db/m3/src/dbnode/encoding/m3tsz	0.494s
ok  	github.com/m3db/m3/src/dbnode/encoding/proto	0.194s
ok  	github.com/m3db/m3/src/dbnode/environment	0.712s
?   	github.com/m3db/m3/src/dbnode/storage/index/segments	[no test files]
?   	github.com/m3db/m3/src/dbnode/test	[no test files]
?   	github.com/m3db/m3/src/dbnode/topology/testutil	[no test files]
?   	github.com/m3db/m3/src/dbnode/tracepoint	[no test files]
?   	github.com/m3db/m3/src/dbnode/x/m3em/convert	[no test files]
?   	github.com/m3db/m3/src/dbnode/x/metrics	[no test files]
?   	github.com/m3db/m3/src/dbnode/x/tchannel	[no test files]
ok  	github.com/m3db/m3/src/dbnode/integration	21.910s
ok  	github.com/m3db/m3/src/dbnode/namespace	6.692s
ok  	github.com/m3db/m3/src/dbnode/namespace/kvadmin	0.339s
ok  	github.com/m3db/m3/src/dbnode/network/server/httpjson	0.250s
ok  	github.com/m3db/m3/src/dbnode/network/server/tchannelthrift	0.454s
ok  	github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/cluster	0.422s
ok  	github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/convert	0.572s
ok  	github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/errors	0.397s
ok  	github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/node	0.673s
ok  	github.com/m3db/m3/src/dbnode/persist/fs	17.246s
ok  	github.com/m3db/m3/src/dbnode/persist/fs/clone	0.624s
ok  	github.com/m3db/m3/src/dbnode/persist/fs/commitlog	2.467s
ok  	github.com/m3db/m3/src/dbnode/persist/fs/migration	0.625s
ok  	github.com/m3db/m3/src/dbnode/persist/fs/msgpack	0.307s
ok  	github.com/m3db/m3/src/dbnode/persist/schema	0.188s
ok  	github.com/m3db/m3/src/dbnode/retention	0.495s
ok  	github.com/m3db/m3/src/dbnode/runtime	0.220s
ok  	github.com/m3db/m3/src/dbnode/server	15.570s
ok  	github.com/m3db/m3/src/dbnode/sharding	0.188s
ok  	github.com/m3db/m3/src/dbnode/storage	13.040s
ok  	github.com/m3db/m3/src/dbnode/storage/block	4.786s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap	0.464s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper	0.377s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog	0.986s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/fs	2.406s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator	0.388s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/peers	1.237s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/uninitialized	0.446s
ok  	github.com/m3db/m3/src/dbnode/storage/bootstrap/result	0.459s
ok  	github.com/m3db/m3/src/dbnode/storage/cluster	2.543s
ok  	github.com/m3db/m3/src/dbnode/storage/errors	0.106s
ok  	github.com/m3db/m3/src/dbnode/storage/index	8.951s
ok  	github.com/m3db/m3/src/dbnode/storage/index/compaction	0.195s
ok  	github.com/m3db/m3/src/dbnode/storage/index/convert	0.211s
ok  	github.com/m3db/m3/src/dbnode/storage/limits	0.408s
ok  	github.com/m3db/m3/src/dbnode/storage/limits/permits	0.177s
ok  	github.com/m3db/m3/src/dbnode/storage/repair	0.256s
ok  	github.com/m3db/m3/src/dbnode/storage/series	0.766s
ok  	github.com/m3db/m3/src/dbnode/topology	0.402s
ok  	github.com/m3db/m3/src/dbnode/ts	0.193s
ok  	github.com/m3db/m3/src/dbnode/ts/writes	0.387s
ok  	github.com/m3db/m3/src/dbnode/x/m3em/node	0.182s
ok  	github.com/m3db/m3/src/dbnode/x/xio	0.194s
ok  	github.com/m3db/m3/src/dbnode/x/xpool	0.154s

```
### Local test on my laptop
```
$ git diff

+++ b/observability/scripts/m3-dev/local/m3db/config.yml
@@ -228,6 +228,13 @@ db:
   # Sets GOGC value.
   gcPercentage: 100

+  tick:
+    minimumInterval: 5s
+    topMetricsToTrack: 100
+    minCardinalityToTrack: 10
+    maxMapLenForTracking: 10000
+    topMetricsTrackingTicks: 5
+

$ observability/scripts/m3-dev/local/start_m3_stack.sh -l /Users/hc.zhu/data/m3.logs -d /Users/hc.zhu/data/m3.data -r /Users/hc.zhu/m3

$ rg TopMetrics ~/data/m3.logs/m3dbnode.log

30:{"level":"info","ts":"2023-03-31T16:02:04.348-0700","msg":"Setting up tick configuration","TopMetricsToTrack":100}
3677:{"level":"info","ts":"2023-03-31T16:02:50.219-0700","msg":"Will track top metrics for this tick.","namespace":"default","TopMetricsTrackingTicks":5,"tickSeqNo":5}
6541:{"level":"info","ts":"2023-03-31T16:03:40.366-0700","msg":"Will track top metrics for this tick.","namespace":"default","TopMetricsTrackingTicks":5,"tickSeqNo":10}
9462:{"level":"info","ts":"2023-03-31T16:04:30.519-0700","msg":"Will track top metrics for this tick.","namespace":"default","TopMetricsTrackingTicks":5,"tickSeqNo":15}
12662:{"level":"info","ts":"2023-03-31T16:05:20.718-0700","msg":"Will track top metrics for this tick.","namespace":"default","TopMetricsTrackingTicks":5,"tickSeqNo":20}
15833:{"level":"info","ts":"2023-03-31T16:06:10.874-0700","msg":"Will track top metrics for this tick.","namespace":"default","TopMetricsTrackingTicks":5,"tickSeqNo":25}

$ curl -s 'http://localhost:9004/metrics' | rg top_metric__ | head
# HELP m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_0 m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_0 gauge
# TYPE m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_0 gauge
m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_0{namespace="default"} 27
# HELP m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_1 m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_1 gauge
# TYPE m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_1 gauge
m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_1{namespace="default"} 18
# HELP m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_3 m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_3 gauge
# TYPE m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_3 gauge
m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_3{namespace="default"} 13
# HELP m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_4 m3db_database_tick_top_metric__avalanche_metric_mmmmm_0_4 gauge

```
### Deploy to the integration test cluster and bake there for one week to collect performance data.

### Deploy it to `dev-aws-us-west-2` and bake there for one week to collect performance data.

## Metric overview
<img width="2114" alt="image" src="https://user-images.githubusercontent.com/2289363/229250062-20425c2c-dfcc-4b64-a612-3613ab5c317e.png">
