### PR TITLE
[PLAT-78692] Optimize m3coord fanout to remote storages

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -264,6 +264,8 @@ const (
 	FilterAllowAll Filter = "allow_all"
 	// FilterAllowNone is a filter that specifies no storages should be used.
 	FilterAllowNone Filter = "allow_none"
+	// This fitler requires a read request be sent to the specific storages if there is any targeted fitler in the query of the request.
+	FilterReadOptimized Filter = "read_optimized"
 )
 
 // FilterConfiguration is the filters for write/read/complete tags storage filters.

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -264,7 +264,7 @@ const (
 	FilterAllowAll Filter = "allow_all"
 	// FilterAllowNone is a filter that specifies no storages should be used.
 	FilterAllowNone Filter = "allow_none"
-	// This fitler requires a read request be sent to the specific storages if there is any targeted fitler in the query of the request.
+	// This filter requires a read request be sent to specific storages if there is any targeted fitler in the query of the request.
 	FilterReadOptimized Filter = "read_optimized"
 )
 

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -1177,6 +1177,9 @@ func newStorages(
 		readFilter = filter.AllowAll
 	case config.FilterAllowNone:
 		readFilter = filter.AllowNone
+	case config.FilterReadOptimized:
+		readFilter = filter.ReadOptimizedFilter
+		logger.Info("Using read optimzied filter for the remote storages", zap.String("Filter.Read", string(config.FilterReadOptimized)))
 	}
 
 	switch cfg.Filter.Write {

--- a/src/query/storage/mock/storage.go
+++ b/src/query/storage/mock/storage.go
@@ -86,11 +86,16 @@ type mockStorage struct {
 		err   error
 	}
 	writes []*storage.WriteQuery
+	name string
 }
 
 // NewMockStorage creates a new mock Storage instance.
 func NewMockStorage() Storage {
-	return &mockStorage{}
+	return &mockStorage{name: "mock"}
+}
+
+func NewMockStorageWithName(name string) Storage {
+	return &mockStorage{name: name}
 }
 
 func (s *mockStorage) FetchCompressed(ctx context.Context,
@@ -264,7 +269,8 @@ func (s *mockStorage) Type() storage.Type {
 }
 
 func (s *mockStorage) Name() string {
-	return "mock"
+	// NB: no need to lock here as name is immutable.
+	return s.name
 }
 
 func (s *mockStorage) ErrorBehavior() storage.ErrorBehavior {


### PR DESCRIPTION
# What this PR does?
If a query has “shardName=” filter, it should only fan out the query to the local storage and the corresponding remote storage.

Example queries:
https://temp.corp.databricks.com/?c16721341d39f4eb#0Y5ZYeVzcbHg1KnhBS0/n+x9GJMjEwZyndLCicQEPtU=

# How is it tested?
## Run the m3 stack locally

### m3dbnode configuration


```
+  filter:
+    read: "read_optimized"
+  "rpc":
+    "enabled": true
+    "errorBehavior": "warn"
+    "listenAddress": "0.0.0.0:7202"
+    "remotes":
+    - "name": "dev-aws-oregon-dev"
+      "remoteListenAddresses":
+      - "localhost:8080"

```
### Port-forward oregon-dev global endpoint
```
$ k-m3 dev-aws-us-west-2 port-forward svc/m3coord-read-global-internal-svc 8080:7202
```
### Relavant m3dbnode logs
Starting logs
```
$ rg -N 'optimized' ~/data/m3.logs/m3dbnode.log

{"level":"info","ts":"2023-04-11T20:07:35.173-0700","msg":"Using read optimzied filter for the remote storages","Filter.Read":"read_optimized"}

$ rg -N 'underlying' ~/data/m3.logs/m3dbnode.log

{"level":"info","ts":"2023-04-11T20:07:35.173-0700","msg":"Created fanout storage with underlying storages","num_stores":2}
{"level":"info","ts":"2023-04-11T20:07:35.173-0700","msg":"The underlying stores: ","store_name":"local_store","store_error_behavior":"fail","store_type":0}
{"level":"info","ts":"2023-04-11T20:07:35.173-0700","msg":"The underlying stores: ","store_name":"remote_store_dev-aws-oregon-dev","store_error_behavior":"fail","store_type":1}

```
Query processing logs
http://localhost:7201/api/v1/query?query=up{shardName=%22oregon-dev-on%22}
```
$ {"level":"info","ts":"2023-04-11T20:25:20.916-0700","msg":"filtered out some storages","num_stores_before_filter":2,"num_stores_after_filter":1}
```
http://localhost:7201/api/v1/query?query=up{shardName=%22oregon-dev%22}

No log for this one because no remote storage is filtered.

## Unit test
```
$ go test -timeout 30s -run ^TestReadOptimizedFilter$ github.com/m3db/m3/src/query/policy/filter
```

## Tested the performance in oregon-dev
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/2289363/231516092-1cb3b6f4-22e5-493e-8a1b-6ec3d9427ff7.png">

<img width="1513" alt="image" src="https://user-images.githubusercontent.com/2289363/231516355-594f3745-8250-48b2-87fc-a5b029991fa0.png">





