### PR TITLE
[PLAT-79912] Read query fan-out optimization supports `shardName=~"aa|bb|cc"`

### DIFF
--- a/src/query/policy/filter/storage.go
+++ b/src/query/policy/filter/storage.go
@@ -72,6 +72,14 @@ func ReadOptimizedFilter(query storage.Query, store storage.Storage) bool {
 				if !strings.HasSuffix(store.Name(), string(tagMatcher.Value)) {
 					return false
 				}
+			case models.MatchRegexp:
+			    // NB: only support 'shardName=~"aaa|bbb|ccc"' for now, where "aaa", "bbb", and "ccc" are plain strings instead of regex.
+				for _, matcherValue := range strings.Split(string(tagMatcher.Value), "|") {
+					if strings.HasSuffix(store.Name(), matcherValue) {
+						return true
+					}
+				}
+				return false
 			}
 		}
 	}


### PR DESCRIPTION
This is to help Evaluation service's query pattern.

```
$ go test -timeout 30s -run ^TestReadOptimizedFilterWithRegex$ github.com/m3db/m3/src/query/policy/filter
```