### PR TITLE
Make read_data_files able to take multiple metrics names in filters

### DIFF
--- a/src/cmd/tools/read_data_files/README.md
+++ b/src/cmd/tools/read_data_files/README.md
@@ -13,7 +13,7 @@ Usage: read_data_files [-B value] [-b value] [-f value] [-n value] [-p value] [-
  -b, --block-start=value
                     Block Start Time [in nsec]
  -f, --id-filter=value
-                    ID Contains Filter (optional)
+                    ID Contains Filter (optional), could be a comma separated list to specify multiple filters")
  -n, --namespace=value
                     Namespace [e.g. metrics]
  -p, --path-prefix=value

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -75,7 +75,7 @@ func main() {
 		optBlockstart  = getopt.Int64Long("block-start", 'b', 0, "Block Start Time [in nsec]")
 		volume         = getopt.Int64Long("volume", 'v', 0, "Volume number")
 		fileSetTypeArg = getopt.StringLong("fileset-type", 't', flushType, fmt.Sprintf("%s|%s", flushType, snapshotType))
-		idFilter       = getopt.StringLong("id-filter", 'f', "", "ID Contains Filter (optional)")
+		idFilter       = getopt.StringLong("id-filter", 'f', "", "ID Contains Filters (optional), could be a comma separated list to specify multiple filters")
 		benchmark      = getopt.StringLong(
 			"benchmark", 'B', "series", "benchmark mode (optional), [series|datapoints]")
 	)

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -88,12 +88,7 @@ func main() {
 	log := rawLogger.Sugar()
 
 	filterIds := strings.Split(*idFilter, ",")
-	filterIdRegex, err := regexp.Compile(strings.Join(filterIds, "|"))
-
-	if err != nil {
-		fmt.Printf("Error compiling regular expression from filter %s: %s\n", *idFilter, err)
-		return
-	}
+	filterIdRegex := regexp.MustCompile(strings.Join(filterIds, "|"))
 
 	if *optPathPrefix == "" ||
 		*optNamespace == "" ||

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -86,6 +86,12 @@ func main() {
 	}
 	log := rawLogger.Sugar()
 
+	filterIds := strings.Split(*idFilter, ",")
+	filterIdSets := make(map[string]bool)
+	for _, filterId := range filterIds {
+		filterIdSets[filterId] = true
+	}
+
 	if *optPathPrefix == "" ||
 		*optNamespace == "" ||
 		*optShard < allShards ||
@@ -180,7 +186,17 @@ func main() {
 				data = entry.Data
 			)
 
-			if *idFilter != "" && !strings.Contains(id.String(), *idFilter) {
+			var filterMatches bool = false
+			var matchedId string = ""
+			for _, filterId := range filterIds {
+				if strings.Contains(id.String(), filterId) {
+					filterMatches = true
+					matchedId = filterId
+					break
+				}
+			}
+
+			if *idFilter != "" && !filterMatches && matchedId == "" {
 				continue
 			}
 

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -87,9 +88,11 @@ func main() {
 	log := rawLogger.Sugar()
 
 	filterIds := strings.Split(*idFilter, ",")
-	filterIdSets := make(map[string]bool)
-	for _, filterId := range filterIds {
-		filterIdSets[filterId] = true
+	filterIdRegex, err := regexp.Compile(strings.Join(filterIds, "|"))
+
+	if err != nil {
+		fmt.Printf("Error compiling regular expression from filter %s: %s\n", *idFilter, err)
+		return
 	}
 
 	if *optPathPrefix == "" ||
@@ -186,17 +189,7 @@ func main() {
 				data = entry.Data
 			)
 
-			var filterMatches bool = false
-			var matchedId string = ""
-			for _, filterId := range filterIds {
-				if strings.Contains(id.String(), filterId) {
-					filterMatches = true
-					matchedId = filterId
-					break
-				}
-			}
-
-			if *idFilter != "" && !filterMatches && matchedId == "" {
+			if *idFilter != "" && !filterIdRegex.MatchString(id.String()) {
 				continue
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:

The `read_data_files` tool can only export one metric at one time, in case we need to export multiple metrics, this means we need to scan the same set of TSDB files repeatedly for different metrics. This change is to make it possible to do a one-pass scan to export multiple metrics into the same file.

If the `-f` parameter passed in is a comma separated list, we will build a regular expression based on it and use that to match multiple metrics when scanning the TSDB files. If there is no comma in the `-f` parameter, it will simply behave same as before.

Tested and proof this is more efficient than running multiple invocations of `read_data_files` (`read_data_files.bak` is the original version and `read_data_files` is the one built with this change):  

```
bash-5.1# time -p ./read_data_files.bak -B datapoints -b 1684944000000000000 -f kube_pod_labels > kube_pod_labels.1684944000000000000.data
real 10.97
user 11.26
sys 0.74
bash-5.1# time -p ./read_data_files.bak -B datapoints -b 1684944000000000000 -f kube_pod_info > kube_pod_info.1684944000000000000.data
real 11.12
user 11.62
sys 0.78
bash-5.1#
bash-5.1# time -p ./read_data_files -B datapoints -b 1684944000000000000 -f kube_pod_info,kube_pod_labels > both.ob.1684944000000000000.data
real 13.35
user 13.90
sys 0.82
```

Also verified the exported metrics line counts are matching:

```
bash-5.1# grep "kube_pod_labels" kube_pod_labels.1684944000000000000.data | wc -l
2158
bash-5.1# grep "kube_pod_info" kube_pod_info.1684944000000000000.data | wc -l
2966
bash-5.1# grep "kube_pod_labels" both.ob.1684944000000000000.data | wc -l
2158
bash-5.1# grep "kube_pod_info" both.ob.1684944000000000000.data | wc -l
2966
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
