### PR TITLE
[PLAT-78900] Remove le when computing shard for metric id

### DIFF
--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -47,6 +47,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"github.com/m3db/m3/src/x/parsers"
 )
 
 const (
@@ -274,7 +275,8 @@ func (agg *aggregator) AddTimedWithStagedMetadatas(
 	sw := agg.metrics.addTimed.SuccessLatencyStopwatch()
 	agg.updateStagedMetadatas(metas)
 	agg.metrics.timed.Inc(1)
-	shard, err := agg.shardFor(metric.ID)
+	shardingId, _ := parsers.GetMetricIDWithoutLe(metric.ID)
+	shard, err := agg.shardFor(shardingId)
 	if err != nil {
 		agg.metrics.addTimed.ReportError(err, agg.electionManager.ElectionState(), agg.logger)
 		return err
@@ -304,7 +306,8 @@ func (agg *aggregator) AddForwarded(
 ) error {
 	sw := agg.metrics.addForwarded.SuccessLatencyStopwatch()
 	agg.metrics.forwarded.Inc(1)
-	shard, err := agg.shardFor(metric.ID)
+	shardingId, _ := parsers.GetMetricIDWithoutLe(metric.ID)
+	shard, err := agg.shardFor(shardingId)
 	if err != nil {
 		agg.metrics.addForwarded.ReportError(err, agg.electionManager.ElectionState(), agg.logger)
 		return err

--- a/src/aggregator/client/m3msg_client.go
+++ b/src/aggregator/client/m3msg_client.go
@@ -38,6 +38,7 @@ import (
 	"github.com/m3db/m3/src/msg/producer"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/instrument"
+	"github.com/m3db/m3/src/x/parsers"
 )
 
 var _ AdminClient = (*M3MsgClient)(nil)
@@ -226,7 +227,8 @@ func (c *M3MsgClient) WriteForwarded(
 
 //nolint:gocritic
 func (c *M3MsgClient) write(metricID id.RawID, payload payloadUnion) error {
-	shard := c.shardFn(metricID, c.m3msg.numShards)
+	shardingId, _ := parsers.GetMetricIDWithoutLe(metricID)
+	shard := c.shardFn(shardingId, c.m3msg.numShards)
 
 	msg := c.m3msg.messagePool.Get()
 	if err := msg.Encode(shard, payload); err != nil {

--- a/src/x/parsers/metric_parsers.go
+++ b/src/x/parsers/metric_parsers.go
@@ -1,0 +1,69 @@
+package parsers
+
+import (
+	"github.com/m3db/m3/src/metrics/metric/id"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
+	"bytes"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/checked"
+)
+
+func getMetricTagsIterator() serialize.MetricTagsIterator {
+	// todo: creating a tag decoder in an ad-hoc manner, replace with our own decoder without the need of a pool
+	poolOpts := pool.NewObjectPoolOptions().SetSize(1)
+	size := 1
+	tagDecoderPool := serialize.NewTagDecoderPool(
+		serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{
+			CheckBytesWrapperPoolSize: &size,
+		}), poolOpts)
+	tagDecoderPool.Init()
+	metricIteratorPool := serialize.NewMetricTagsIteratorPool(tagDecoderPool, poolOpts)
+	metricIteratorPool.Init()
+
+	return metricIteratorPool.Get()
+}
+
+func getNewID(tags []ident.Tag) (id.RawID, bool) {
+	tagEncoderPool := serialize.NewTagEncoderPool(serialize.NewTagEncoderOptions(),
+		pool.NewObjectPoolOptions().SetSize(1))
+	tagEncoderPool.Init()
+
+	tagEncoder := tagEncoderPool.Get()
+	err := tagEncoder.Encode(ident.NewTagsIterator(ident.NewTags(tags...)))
+	if err != nil {
+		return nil, false
+	}
+
+	data, ok := tagEncoder.Data()
+	if !ok {
+		return nil, false
+	}
+
+	return data.Bytes(), true
+}
+
+// GetMetricIDWithoutLe returns a metric id (with sorted tag pairs) without the le tag
+func GetMetricIDWithoutLe(metricID id.RawID) (id.RawID, bool) {
+	it := getMetricTagsIterator()
+	it.Reset(metricID)
+	leTagName := []byte("le")
+	if _, ok := it.TagValue(leTagName); !ok {
+		// metricID does not have the le tag
+		return metricID, false
+	}
+
+	var tagsWithoutLe []ident.Tag
+	for it.Next() {
+		tagName, tagValue := it.Current()
+
+		if !bytes.Equal(tagName, leTagName) {
+			tagsWithoutLe = append(tagsWithoutLe, ident.BinaryTag(checked.NewBytes(tagName, nil), checked.NewBytes(tagValue, nil)))
+		}
+	}
+	idWithoutLe, ok := getNewID(tagsWithoutLe)
+	if !ok {
+		return metricID, false
+	}
+	return idWithoutLe, true
+}

--- a/src/x/parsers/metric_parsers.go
+++ b/src/x/parsers/metric_parsers.go
@@ -2,50 +2,13 @@ package parsers
 
 import (
 	"github.com/m3db/m3/src/metrics/metric/id"
-	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/serialize"
 	"bytes"
-	"github.com/m3db/m3/src/x/ident"
-	"github.com/m3db/m3/src/x/checked"
 )
-
-func getMetricTagsIterator() serialize.MetricTagsIterator {
-	// todo: creating a tag decoder in an ad-hoc manner, replace with our own decoder without the need of a pool
-	poolOpts := pool.NewObjectPoolOptions().SetSize(1)
-	size := 1
-	tagDecoderPool := serialize.NewTagDecoderPool(
-		serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{
-			CheckBytesWrapperPoolSize: &size,
-		}), poolOpts)
-	tagDecoderPool.Init()
-	metricIteratorPool := serialize.NewMetricTagsIteratorPool(tagDecoderPool, poolOpts)
-	metricIteratorPool.Init()
-
-	return metricIteratorPool.Get()
-}
-
-func getNewID(tags []ident.Tag) (id.RawID, bool) {
-	tagEncoderPool := serialize.NewTagEncoderPool(serialize.NewTagEncoderOptions(),
-		pool.NewObjectPoolOptions().SetSize(1))
-	tagEncoderPool.Init()
-
-	tagEncoder := tagEncoderPool.Get()
-	err := tagEncoder.Encode(ident.NewTagsIterator(ident.NewTags(tags...)))
-	if err != nil {
-		return nil, false
-	}
-
-	data, ok := tagEncoder.Data()
-	if !ok {
-		return nil, false
-	}
-
-	return data.Bytes(), true
-}
 
 // GetMetricIDWithoutLe returns a metric id (with sorted tag pairs) without the le tag
 func GetMetricIDWithoutLe(metricID id.RawID) (id.RawID, bool) {
-	it := getMetricTagsIterator()
+	it := serialize.NewUncheckedMetricTagsIterator(serialize.NewTagSerializationLimits())
 	it.Reset(metricID)
 	leTagName := []byte("le")
 	if _, ok := it.TagValue(leTagName); !ok {
@@ -53,17 +16,14 @@ func GetMetricIDWithoutLe(metricID id.RawID) (id.RawID, bool) {
 		return metricID, false
 	}
 
-	var tagsWithoutLe []ident.Tag
+	var idWithoutLe []byte
 	for it.Next() {
 		tagName, tagValue := it.Current()
 
 		if !bytes.Equal(tagName, leTagName) {
-			tagsWithoutLe = append(tagsWithoutLe, ident.BinaryTag(checked.NewBytes(tagName, nil), checked.NewBytes(tagValue, nil)))
+			idWithoutLe = append(idWithoutLe, tagName...)
+			idWithoutLe = append(idWithoutLe, tagValue...)
 		}
-	}
-	idWithoutLe, ok := getNewID(tagsWithoutLe)
-	if !ok {
-		return metricID, false
 	}
 	return idWithoutLe, true
 }

--- a/src/x/parsers/metric_parsers_test.go
+++ b/src/x/parsers/metric_parsers_test.go
@@ -80,7 +80,7 @@ func TestGetMetricIDWithoutLe(t *testing.T) {
 		{
 			testName:         "test original metric id with le returns a modified id without le",
 			originalMetricID: idWithLe.Bytes(),
-			expectedMetricID: idWithoutLe.Bytes(),
+			expectedMetricID: []byte("foobark1k2"),
 			expectedLeResult: true,
 		},
 	}

--- a/src/x/parsers/metric_parsers_test.go
+++ b/src/x/parsers/metric_parsers_test.go
@@ -1,0 +1,93 @@
+package parsers
+
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+	"github.com/m3db/m3/src/metrics/metric/id"
+	"github.com/m3db/m3/src/x/serialize"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/ident"
+	"sort"
+)
+
+func newTestID(t *testing.T, tags map[string]string) id.ID {
+	tagEncoderPool := serialize.NewTagEncoderPool(serialize.NewTagEncoderOptions(),
+		pool.NewObjectPoolOptions().SetSize(1))
+	tagEncoderPool.Init()
+
+	var stringTags []ident.Tag
+	tagNames := make([]string, 0, len(tags))
+	for name, _ := range tags {
+		tagNames = append(tagNames, name)
+	}
+	sort.Strings(tagNames)
+	for _, name := range tagNames {
+		value := tags[name]
+		stringTags = append(stringTags, ident.StringTag(name, value))
+	}
+
+	tagEncoder := tagEncoderPool.Get()
+	err := tagEncoder.Encode(ident.NewTagsIterator(ident.NewTags(stringTags...)))
+	require.NoError(t, err)
+
+	data, ok := tagEncoder.Data()
+	require.True(t, ok)
+
+	size := 1
+	tagDecoderPool := serialize.NewTagDecoderPool(
+		serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{
+			CheckBytesWrapperPoolSize: &size,
+		}),
+		pool.NewObjectPoolOptions().SetSize(size))
+	tagDecoderPool.Init()
+
+	tagDecoder := tagDecoderPool.Get()
+
+	iter := serialize.NewMetricTagsIterator(tagDecoder, nil)
+	iter.Reset(data.Bytes())
+	return iter
+}
+
+func copyTags(tags map[string]string) map[string]string {
+	copy := make(map[string]string)
+	for k, v := range tags {
+		copy[k] = v
+	}
+	return copy
+}
+func TestGetMetricIDWithoutLe(t *testing.T) {
+	tagsWithoutLe := make(map[string]string)
+	tagsWithoutLe["foo"] = "bar"
+	tagsWithoutLe["k1"] = "k2"
+	tagsWithLe := copyTags(tagsWithoutLe)
+	tagsWithLe["le"] = "0.0"
+	idWithoutLe := newTestID(t, tagsWithoutLe)
+	idWithLe := newTestID(t, tagsWithLe)
+
+	type testCase struct {
+		originalMetricID id.RawID
+		expectedMetricID id.RawID
+		expectedLeResult bool
+		testName         string
+	}
+	testCases := []testCase{
+		{
+			testName:         "test original metric id without le returns the original metric id",
+			originalMetricID: idWithoutLe.Bytes(),
+			expectedMetricID: idWithoutLe.Bytes(),
+			expectedLeResult: false,
+		},
+		{
+			testName:         "test original metric id with le returns a modified id without le",
+			originalMetricID: idWithLe.Bytes(),
+			expectedMetricID: idWithoutLe.Bytes(),
+			expectedLeResult: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualMetricID, actualLeResult := GetMetricIDWithoutLe(testCase.originalMetricID)
+		require.Equal(t, testCase.expectedLeResult, actualLeResult, testCase.testName)
+		require.Equal(t, testCase.expectedMetricID, actualMetricID, testCase.testName)
+	}
+}


### PR DESCRIPTION
## Context
- We need to send all buckets of a histogram to the same aggregator shard so that in the event of an agg instance restart, all histogram buckets are reset to 0 and there is no undefined behavior when we use `histogram_quantile()`. See [this doc](https://docs.google.com/document/d/1A7uB2KaqDG2G_cgiPq7ffZ9zxXO6rtyTaO3D7WuOOAU/edit#) for more details about this issue. 
## Changelog
- Add function to 1) check if the metric id has 'le' meaning it is a histogram metric and 2) return a metric id without 'le' label
- Use this function in coordinator and aggregator handlers when forwarding the metric to different pipeline stages
## Testing
- Unit tested in metric_parsers_test
- Deployed to dev-aws-us-west-2 and restarted one aggregator leader instance. Observed all buckets reset to 0 and no spikes in agg metric vs original metric:
![image](https://github.com/databricks/m3/assets/85959671/3a8c9d9e-0b69-4c52-97f3-af8f57b0096a)
