### PR TITLE
Get volume number from m3db file name in read_data_files

### DIFF
--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -152,7 +152,7 @@ func main() {
 
 		volumeNum, err := getVolumeNumber(*optPathPrefix, *optNamespace, int(shard), strconv.FormatInt(*optBlockstart, 10))
 		if err != nil {
-			log.Errorf("Failed to get volume number from file names for shard %d, using default shard number 0", shard)
+			log.Errorf("Failed to get volume number from file names for shard %d, using volume number %d from command line", shard, *volume)
 			volumeNum = int(*volume)
 		}
 
@@ -262,7 +262,6 @@ func getVolumeNumber(pathPrefix string, namespace string, shard int, blockStart 
 		return 0, fmt.Errorf("failed reading data directory: %w", err)
 	}
 
-	volumeSet := make(map[int]struct{})
 	maxVolumeNum := 0
 	for _, f := range files {
 		if f.IsDir() {
@@ -277,7 +276,6 @@ func getVolumeNumber(pathPrefix string, namespace string, shard int, blockStart 
 				if err != nil {
 					fmt.Errorf("failed parsing volume directory: %w", err)
 				} else {
-					volumeSet[volumeNum] = struct{}{}
 					if volumeNum > maxVolumeNum {
 						maxVolumeNum = volumeNum
 					}
@@ -288,10 +286,6 @@ func getVolumeNumber(pathPrefix string, namespace string, shard int, blockStart 
 		}
 	}
 
-	volumeNums := make([]int, 0, len(volumeSet))
-	for volume := range volumeSet {
-		volumeNums = append(volumeNums, volume)
-	}
 	return maxVolumeNum, nil
 }
 

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -153,7 +153,7 @@ func main() {
 		volumeNums, err := getVolumeNumber(*optPathPrefix, *optNamespace, int(shard), strconv.FormatInt(*optBlockstart, 10))
 		if err != nil {
 			log.Errorf("Failed to get volume number from file names for shard %d, using default shard number 0", shard)
-			volumeNums = []int{0}
+			volumeNums = []int{int(*volume)}
 		}
 
 		for volume := range volumeNums {

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -156,7 +156,7 @@ func main() {
 			volumeNums = []int{int(*volume)}
 		}
 
-		for volume := range volumeNums {
+		for _, volume := range volumeNums {
 
 		openOpts := fs.DataReaderOpenOptions{
 			Identifier: fs.FileSetFileIdentifier{
@@ -171,7 +171,7 @@ func main() {
 
 		err = reader.Open(openOpts)
 		if err != nil {
-			log.Fatalf("unable to open reader for shard %v: %v", shard, err)
+			log.Fatalf("unable to open reader for shard %v and volume %v: %v, openOpts: %s", shard, volume, err, openOpts)
 		}
 
 		for {

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -61,7 +61,7 @@ const (
 
 	// The maximum number of delimeters ('-' or '.') that is expected in a
 	// (base) filename.
-	maxDelimNum = 4
+	MaxDelimNum = 4
 
 	// The volume index assigned to (legacy) filesets that don't have a volume
 	// number in their filename.
@@ -417,9 +417,9 @@ func (a commitlogsByTimeAndIndexAscending) Less(i, j int) bool {
 // optimized for speed and lack of allocations, since allocation-heavy filename
 // parsing can quickly become a large source of allocations in the entire
 // system, especially when namespaces with long retentions are configured.
-func delimiterPositions(baseFilename string) ([maxDelimNum]int, int) {
+func delimiterPositions(baseFilename string) ([MaxDelimNum]int, int) {
 	var (
-		delimPos    [maxDelimNum]int
+		delimPos    [MaxDelimNum]int
 		delimsFound int
 	)
 
@@ -445,7 +445,7 @@ func delimiterPositions(baseFilename string) ([maxDelimNum]int, int) {
 func intComponentAtIndex(
 	baseFilename string,
 	componentPos int,
-	delimPos [maxDelimNum]int,
+	delimPos [MaxDelimNum]int,
 ) (xtime.UnixNano, error) {
 	start := 0
 	if componentPos > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
`read_data_files` will use the default volume number 0 when not specified from command line. This default value works fine in most cases but under some circumstances it will not be able to find the shard's data file. Given the volume number is in the shard data file's name, we can dynamically find the volume numbers belongs to a shard by checking file names. 
**Testing done**

Original we are getting failure when running command like:
```
bash-5.1# ./read_data_files -B datapoints -b 1685376000000000000 -f kube_node_labels > test.kube_node_labels.1685376000000000000.orig.data
2023-05-31T00:21:58.986Z        FATAL   main/main.go:166        unable to open reader for shard 101: checkpoint file does not exist
main.main
        /Users/yi.jin/repos/m3/src/cmd/tools/read_data_files/main/main.go:166
runtime.main
        /usr/local/Cellar/go/1.19.1/libexec/src/runtime/proc.go:250
```

After this change the error is gone and we can confirm the data is exported successfully, without providing shard number and volume number from command line:
```
bash-5.1# ./read_data_files.new -B datapoints -b 1685376000000000000 -f kube_node_labels > test.kube_node_labels.1685376000000000000.new.data
bash-5.1# echo $?
0
bash-5.1# ls -l test.kube_node_labels.1685376000000000000.*.data
-rw-r--r--    1 root     root        364956 May 31 00:26 test.kube_node_labels.1685376000000000000.new.data
-rw-r--r--    1 root     root            38 May 31 00:25 test.kube_node_labels.1685376000000000000.orig.data
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
