### PR TITLE
[PLAT-78900] Support histogram metric aggregation

### DIFF
--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -47,6 +47,8 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"github.com/m3db/m3/src/x/parsers"
+	"fmt"
 )
 
 const (
@@ -274,11 +276,21 @@ func (agg *aggregator) AddTimedWithStagedMetadatas(
 	sw := agg.metrics.addTimed.SuccessLatencyStopwatch()
 	agg.updateStagedMetadatas(metas)
 	agg.metrics.timed.Inc(1)
-	shard, err := agg.shardFor(metric.ID)
+	shardingId, isHistogram := parsers.GetMetricIDForHistogramAgg(metric.ID)
+	shard, err := agg.shardFor(shardingId)
+
 	if err != nil {
 		agg.metrics.addTimed.ReportError(err, agg.electionManager.ElectionState(), agg.logger)
 		return err
 	}
+
+	if isHistogram {
+		agg.metrics.histogramSupportScope.Tagged(map[string]string{
+			"shard": fmt.Sprintf("%d", shard.shard),
+		}).Counter("shardCounter").Inc(1)
+		agg.logger.Debug("forwarding histogram metric from aggregator to aggregator shard", zap.Uint32("shardId", shard.shard), zap.ByteString("metricId", metric.ID))
+	}
+
 	if err = shard.AddTimedWithStagedMetadatas(metric, metas); err != nil {
 		agg.metrics.addTimed.ReportError(err, agg.electionManager.ElectionState(), agg.logger)
 		return err
@@ -304,11 +316,21 @@ func (agg *aggregator) AddForwarded(
 ) error {
 	sw := agg.metrics.addForwarded.SuccessLatencyStopwatch()
 	agg.metrics.forwarded.Inc(1)
-	shard, err := agg.shardFor(metric.ID)
+	shardingId, isHistogram := parsers.GetMetricIDForHistogramAgg(metric.ID)
+	shard, err := agg.shardFor(shardingId)
+
 	if err != nil {
 		agg.metrics.addForwarded.ReportError(err, agg.electionManager.ElectionState(), agg.logger)
 		return err
 	}
+
+	if isHistogram {
+		agg.metrics.histogramSupportScope.Tagged(map[string]string{
+			"shard": fmt.Sprintf("%d", shard.shard),
+		}).Counter("shardCounter").Inc(1)
+		agg.logger.Debug("forwarding histogram metric from aggregator to aggregator shard", zap.Uint32("shardId", shard.shard), zap.ByteString("metricId", metric.ID))
+	}
+
 	if err = shard.AddForwarded(metric, metadata); err != nil {
 		agg.metrics.addForwarded.ReportError(err, agg.electionManager.ElectionState(), agg.logger)
 		return err
@@ -1176,6 +1198,8 @@ type aggregatorMetrics struct {
 	shards         aggregatorShardsMetrics
 	shardSetID     aggregatorShardSetIDMetrics
 	tick           aggregatorTickMetrics
+
+	histogramSupportScope tally.Scope
 }
 
 func newAggregatorMetrics(
@@ -1191,23 +1215,25 @@ func newAggregatorMetrics(
 	shardsScope := scope.SubScope("shards")
 	shardSetIDScope := scope.SubScope("shard-set-id")
 	tickScope := scope.SubScope("tick")
+	histogramSupportScope := scope.SubScope("histogram")
 	return aggregatorMetrics{
-		counters:       scope.Counter("counters"),
-		timers:         scope.Counter("timers"),
-		timerBatches:   scope.Counter("timer-batches"),
-		gauges:         scope.Counter("gauges"),
-		forwarded:      scope.Counter("forwarded"),
-		timed:          scope.Counter("timed"),
-		passthrough:    scope.Counter("passthrough"),
-		untimedToTimed: scope.Counter("untimed-to-timed"),
-		addUntimed:     newAggregatorAddUntimedMetrics(addUntimedScope, opts),
-		addTimed:       newAggregatorAddTimedMetrics(addTimedScope, opts),
-		addForwarded:   newAggregatorAddForwardedMetrics(addForwardedScope, opts, maxAllowedForwardingDelayFn),
-		addPassthrough: newAggregatorAddPassthroughMetrics(addPassthroughScope, opts),
-		placement:      newAggregatorPlacementMetrics(placementScope),
-		shards:         newAggregatorShardsMetrics(shardsScope),
-		shardSetID:     newAggregatorShardSetIDMetrics(shardSetIDScope),
-		tick:           newAggregatorTickMetrics(tickScope),
+		counters:              scope.Counter("counters"),
+		timers:                scope.Counter("timers"),
+		timerBatches:          scope.Counter("timer-batches"),
+		gauges:                scope.Counter("gauges"),
+		forwarded:             scope.Counter("forwarded"),
+		timed:                 scope.Counter("timed"),
+		passthrough:           scope.Counter("passthrough"),
+		untimedToTimed:        scope.Counter("untimed-to-timed"),
+		addUntimed:            newAggregatorAddUntimedMetrics(addUntimedScope, opts),
+		addTimed:              newAggregatorAddTimedMetrics(addTimedScope, opts),
+		addForwarded:          newAggregatorAddForwardedMetrics(addForwardedScope, opts, maxAllowedForwardingDelayFn),
+		addPassthrough:        newAggregatorAddPassthroughMetrics(addPassthroughScope, opts),
+		placement:             newAggregatorPlacementMetrics(placementScope),
+		shards:                newAggregatorShardsMetrics(shardsScope),
+		shardSetID:            newAggregatorShardSetIDMetrics(shardSetIDScope),
+		tick:                  newAggregatorTickMetrics(tickScope),
+		histogramSupportScope: histogramSupportScope,
 	}
 }
 

--- a/src/x/parsers/metric_parsers.go
+++ b/src/x/parsers/metric_parsers.go
@@ -1,0 +1,60 @@
+package parsers
+
+import (
+	"bytes"
+
+	"github.com/m3db/m3/src/metrics/metric/id"
+	"github.com/m3db/m3/src/x/serialize"
+)
+
+// GetMetricIDForHistogramAgg returns a metric id (with sorted tag pairs) without the le tag (if is a histogram) and
+// strips histogram suffixes ("_bucket", "_sum". "_count")
+func GetMetricIDForHistogramAgg(metricID id.RawID) (id.RawID, bool) {
+	it := serialize.NewUncheckedMetricTagsIterator(serialize.NewTagSerializationLimits())
+	it.Reset(metricID)
+	leTagName := []byte("le")
+	nameTagName := []byte("__name__")
+
+	bucketSuffix := []byte("_bucket")
+	countSuffix := []byte("_count")
+	sumSuffix := []byte("_sum")
+
+	isHistogram := false
+	isBucketMetric := false
+
+	var idForHistogramAgg []byte
+	for it.Next() {
+		tagName, tagValue := it.Current()
+
+		if bytes.Equal(tagName, nameTagName) {
+			// if the __name__ contains a histogram suffix, then we strip the suffix
+			isHistogram = true
+			switch {
+			case bytes.HasSuffix(tagValue, bucketSuffix):
+				tagValue = tagValue[:len(tagValue)-len(bucketSuffix)]
+				isBucketMetric = true
+			case bytes.HasSuffix(tagValue, countSuffix):
+				tagValue = tagValue[:len(tagValue)-len(countSuffix)]
+			case bytes.HasSuffix(tagValue, sumSuffix):
+				tagValue = tagValue[:len(tagValue)-len(sumSuffix)]
+			default:
+				isHistogram = false
+			}
+
+			if !isHistogram {
+				// if the __name__ does not contain a histogram suffix, then return original metricID
+				// since the metric is not a histogram
+				return metricID, false
+			}
+		} else if isBucketMetric && bytes.Equal(tagName, leTagName) {
+			// if the metric is a bucket metric, then we strip the le tag
+			// we assume __name__ is the first tag in the metric id, so if we see the metric contains '_bucket' suffix,
+			// it must also have a le tag as per the prometheus histogram convention
+			continue
+		}
+
+		idForHistogramAgg = append(idForHistogramAgg, tagName...)
+		idForHistogramAgg = append(idForHistogramAgg, tagValue...)
+	}
+	return idForHistogramAgg, isHistogram
+}

--- a/src/x/parsers/metric_parsers_test.go
+++ b/src/x/parsers/metric_parsers_test.go
@@ -1,0 +1,124 @@
+package parsers
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/m3db/m3/src/metrics/metric/id"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestID(t *testing.T, tags map[string]string) id.ID {
+	tagEncoderPool := serialize.NewTagEncoderPool(serialize.NewTagEncoderOptions(),
+		pool.NewObjectPoolOptions().SetSize(1))
+	tagEncoderPool.Init()
+
+	var stringTags []ident.Tag
+	tagNames := make([]string, 0, len(tags))
+	for name, _ := range tags {
+		tagNames = append(tagNames, name)
+	}
+	sort.Strings(tagNames)
+	for _, name := range tagNames {
+		value := tags[name]
+		stringTags = append(stringTags, ident.StringTag(name, value))
+	}
+
+	tagEncoder := tagEncoderPool.Get()
+	err := tagEncoder.Encode(ident.NewTagsIterator(ident.NewTags(stringTags...)))
+	require.NoError(t, err)
+
+	data, ok := tagEncoder.Data()
+	require.True(t, ok)
+
+	size := 1
+	tagDecoderPool := serialize.NewTagDecoderPool(
+		serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{
+			CheckBytesWrapperPoolSize: &size,
+		}),
+		pool.NewObjectPoolOptions().SetSize(size))
+	tagDecoderPool.Init()
+
+	tagDecoder := tagDecoderPool.Get()
+
+	iter := serialize.NewMetricTagsIterator(tagDecoder, nil)
+	iter.Reset(data.Bytes())
+	return iter
+}
+
+func copyTags(tags map[string]string) map[string]string {
+	copy := make(map[string]string)
+	for k, v := range tags {
+		copy[k] = v
+	}
+	return copy
+}
+func TestGetMetricIDForHistogramAgg(t *testing.T) {
+	tagsWithoutLe := make(map[string]string)
+	tagsWithoutLe["__name__"] = "metric"
+	tagsWithoutLe["foo"] = "bar"
+	tagsWithoutLe["k1"] = "k2"
+	tagsWithLe := copyTags(tagsWithoutLe)
+	tagsWithLe["le"] = "0.0"
+	tagsWithLe["__name__"] = "metric_bucket"
+	idWithoutLe := newTestID(t, tagsWithoutLe)
+	idWithLe := newTestID(t, tagsWithLe)
+	idWithBucketSuffix := newTestID(t, map[string]string{"__name__": "metric_bucket"})
+	idWithSumSuffix := newTestID(t, map[string]string{"__name__": "metric_sum"})
+	idWithCountSuffix := newTestID(t, map[string]string{"__name__": "metric_count"})
+	idWithBucketSuffixWithLeAndOtherLabels := newTestID(t, map[string]string{"FOO": "foo", "__name__": "metric_bucket", "le": "0.0"})
+
+	type testCase struct {
+		originalMetricID    id.RawID
+		expectedMetricID    id.RawID
+		expectedIsHistogram bool
+		testName            string
+	}
+	testCases := []testCase{
+		{
+			testName:            "test original metric id without le returns the original metric id",
+			originalMetricID:    idWithoutLe.Bytes(),
+			expectedMetricID:    idWithoutLe.Bytes(),
+			expectedIsHistogram: false,
+		},
+		{
+			testName:            "test original metric id with le returns a modified id without le",
+			originalMetricID:    idWithLe.Bytes(),
+			expectedMetricID:    []byte("__name__metricfoobark1k2"),
+			expectedIsHistogram: true,
+		},
+		{
+			testName:            "test original metric id with _bucket suffix returns a modified id where __name__ does not have _bucket suffix",
+			originalMetricID:    idWithBucketSuffix.Bytes(),
+			expectedMetricID:    []byte("__name__metric"),
+			expectedIsHistogram: true,
+		},
+		{
+			testName:            "test original metric id with _sum suffix returns a modified id where __name__ does not have _sum suffix",
+			originalMetricID:    idWithSumSuffix.Bytes(),
+			expectedMetricID:    []byte("__name__metric"),
+			expectedIsHistogram: true,
+		},
+		{
+			testName:            "test original metric id with _count suffix returns a modified id where __name__ does not have _count suffix",
+			originalMetricID:    idWithCountSuffix.Bytes(),
+			expectedMetricID:    []byte("__name__metric"),
+			expectedIsHistogram: true,
+		},
+		{
+			testName:            "test original metric id with _count suffix and other labels (including le) returns a modified id where __name__ does not have _count suffix",
+			originalMetricID:    idWithBucketSuffixWithLeAndOtherLabels.Bytes(),
+			expectedMetricID:    []byte("FOOfoo__name__metric"),
+			expectedIsHistogram: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualMetricID, actualLeResult := GetMetricIDForHistogramAgg(testCase.originalMetricID)
+		require.Equal(t, testCase.expectedIsHistogram, actualLeResult, testCase.testName)
+		require.Equal(t, testCase.expectedMetricID, actualMetricID, testCase.testName)
+	}
+}


### PR DESCRIPTION
## Changelog 
- This PR builds on top of https://github.com/databricks/m3/pull/51. #51 was reverted, but this PR brings it back with a slight modification of the sharding scheme.
- Instead of only removing `le` from the metric id, we also need to remove the `_bucket`, `_count` and `_sum` suffixes from the auto-generated histogram metrics by prometheus. This is because the `histogram_quantile()` relies on these other metrics for quantile calculation, therefore, all these metrics need to be sharded to the same shard (so on restarts they all reset at the same time).

## Testing
- Unit tests at metric_parsers_test.go
- Deployed coordinator and aggregator image to `oregon-dev`, tested out restarting aggregator and observed no spikes in the metric
<img width="1655" alt="image" src="https://github.com/databricks/m3/assets/85959671/f9fa4c94-d0c8-4b59-8287-6d0440ffb99e">
- Also observed no increase in resource consumption from agg/coord using go/preaggdash
<img width="417" alt="image" src="https://github.com/databricks/m3/assets/85959671/eef2cdd6-6806-439b-b72a-e45eae356bbb">
<img width="422" alt="image" src="https://github.com/databricks/m3/assets/85959671/8dca465f-bde8-460d-bf0b-cbaa69fe1862">
- no sustained error rate for add timed throughput:
<img width="1641" alt="image" src="https://github.com/databricks/m3/assets/85959671/67e357bf-5d94-46b7-be69-968b2a9744e6">

- further testing: we need to bake this in dev for a week and ensure there are no spikes in the aggregated metric


