### PR TITLE
[PLAT-85130] reject old samples in write coordinator

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -185,6 +185,9 @@ type Configuration struct {
 	// Middleware is middleware-specific configuration.
 	Middleware MiddlewareConfiguration `yaml:"middleware"`
 
+	// Remote Write Config tells how to deal with incoming prometheus remote write requests
+	RemoteWrite RemoteWriteConfiguration `yaml:"remoteWrite"`
+
 	// Query is the query configuration.
 	Query QueryConfiguration `yaml:"query"`
 
@@ -280,6 +283,17 @@ type ResultOptions struct {
 	// KeepNaNs keeps NaNs before returning query results.
 	// The default is false, which matches Prometheus
 	KeepNaNs bool `yaml:"keepNans"`
+}
+
+// RemoteWriteConfiguration deals with incoming metrics samples from remote write requests
+type RemoteWriteConfiguration struct {
+	// If RejectOldSamples is true then m3 coordinator will reject samples directly from remote write requests
+	// It will silently drop old samples without notifying client for retries or report error codes
+	RejectOldSamples bool `yaml:"rejectOldSamples"`
+	// RejectDuration will drop any samples with timestamp t < now - reject_duration
+	RejectDuration time.Duration `yaml:"rejectDuration"`
+	// The sampling rate for error logs
+	ErrorSamplingRate float32 `yaml:"errorSamplingRate" validate:"min=0.0, max=1.0"`
 }
 
 // QueryConfiguration is the query configuration.


### PR DESCRIPTION
This implementation will not try to allocate new memory for dropped samples or time series.

### Unit Tests

```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestPromWriteParsingRejectOldSamples$ github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote

=== RUN   TestPromWriteParsingRejectOldSamples
{"level":"info","ts":1688693845.0596979,"msg":"set up remote write options","reject old samples":true,"reject duration":0.000000001}
{"level":"error","ts":1688693845.060012,"msg":"reject old samples","labels":["__name__=first,","foo=bar,","biz=baz,"],"now":1688693845.0600069,"sample timestamp":1688693845.059}
{"level":"error","ts":1688693845.0600262,"msg":"reject old samples","labels":["__name__=second,","foo=qux,","bar=baz,"],"now":1688693845.0600069,"sample timestamp":1688693845.059}
--- PASS: TestPromWriteParsingRejectOldSamples (0.04s)
PASS
ok      github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote   0.949s

```

Deployed to dev integration test cluster, and set reject duration to be 30s and see:

<img width="1411" alt="Screenshot 2023-07-11 at 10 06 00 AM" src="https://github.com/databricks/m3/assets/96499497/1e4fcdab-534e-4123-be97-8485baf96180">

```
{"level":"info","ts":1689064003.9661903,"msg":"set up remote write options","reject old samples":true,"reject duration":30}

....

{"level":"error","ts":1689089469.9637685,"msg":"reject old samples","labels":["__name__=container_threads_max,","cloud=aws,","clusterType=Obs,","container=node-exporter,","container_name=node-exporter,","env=dev,","internal_ip=172.28.73.96,","job=kubernetes-cadvisor,","k8s_io_cloud_provider_aws=94bc3b5b01398a6686facbd07aa0ca4b,","kubeami=d1fb8088-202304052149stable,","kubernetes_pod_node_name=ip-172-28-73-96.ec2.internal,","namespace=node-exporter,","pod=node-exporter-fqvw7,","pod_name=node-exporter-fqvw7,","region=us-east-1,","shardName=aws-us-east-1-obs-integrationtest,"],"now":1689089469.963763,"sample timestamp":1689089437.349}
{"level":"error","ts":1689089649.9641395,"msg":"reject old samples","labels":["__name__=container_threads_max,","cloud=aws,","clusterType=Obs,","container=pause,","container_name=pause,","env=dev,","internal_ip=172.28.73.96,","job=kubernetes-cadvisor,","k8s_io_cloud_provider_aws=94bc3b5b01398a6686facbd07aa0ca4b,","kubeami=d1fb8088-202304052149stable,","kubernetes_pod_node_name=ip-172-28-73-96.ec2.internal,","namespace=kube-system,","pod=node-initializer-6vkvf,","pod_name=node-initializer-6vkvf,","region=us-east-1,","shardName=aws-us-east-1-obs-integrationtest,"],"now":1689089649.9641333,"sample timestamp":1689089619.753}
```