### PR TITLE
[ES-808858] update query limits stored in etcd

### DIFF
--- a/src/cmd/tools/m3ctl/etcd/etcd.go
+++ b/src/cmd/tools/m3ctl/etcd/etcd.go
@@ -1,0 +1,80 @@
+package etcd
+
+import (
+	"fmt"
+	etcd "github.com/m3db/m3/src/cluster/client/etcd"
+	"github.com/m3db/m3/src/cluster/generated/proto/kvpb"
+	"github.com/m3db/m3/src/cluster/kv"
+	"github.com/m3db/m3/src/dbnode/kvconfig"
+	"go.uber.org/zap"
+)
+
+func getEctdClient(endpoint string) (kv.Store, error) {
+	cluster := etcd.NewCluster().
+		SetZone("embedded").
+		SetEndpoints([]string{endpoint})
+	opts := etcd.NewOptions().
+		SetService("m3db").
+		SetEnv("m3/m3db").
+		SetZone("embedded").
+		SetClusters([]etcd.Cluster{cluster})
+	client, err := etcd.NewConfigServiceClient(opts)
+	if err != nil {
+		return nil, err
+	}
+	kvOpts := kv.NewOverrideOptions()
+	kvOpts.SetZone("embedded")
+	kvOpts.SetEnvironment("m3db")
+	return client.Store(kvOpts)
+}
+
+func DoGet(
+	endpoint string,
+	logger *zap.Logger,
+) ([]byte, error) {
+	store, err := getEctdClient(endpoint)
+	if err != nil {
+		logger.Error("Can't access kv store", zap.Error(err))
+		return nil, err
+	}
+	value, err := store.Get(kvconfig.QueryLimits)
+	if err != nil {
+		logger.Warn("error resolving query limit", zap.Error(err))
+		return nil, err
+	}
+
+	dynamicLimits := &kvpb.QueryLimits{}
+	err = value.Unmarshal(dynamicLimits)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("output", zap.Any("proto", dynamicLimits))
+	s := fmt.Sprintf("%d", dynamicLimits.MaxRecentlyQueriedSeriesDiskBytesRead.Limit)
+	return []byte(s), nil
+}
+
+func DoUpdate(endpoint string, limits int64, logger *zap.Logger) ([]byte, error) {
+	if limits <= 0 {
+		logger.Error("Can't set limits to be non positive", zap.Int64("limits", limits))
+		return nil, nil
+	}
+	store, err := getEctdClient(endpoint)
+	if err != nil {
+		logger.Error("Can't access kv store", zap.Error(err))
+		return nil, err
+	}
+	ql := kvpb.QueryLimit{
+		Limit:           limits,
+		LookbackSeconds: 15,
+	}
+	queryLimits := kvpb.QueryLimits{
+		MaxRecentlyQueriedSeriesDiskBytesRead: &ql,
+	}
+	version, err := store.Set(kvconfig.QueryLimits, &queryLimits)
+	if err != nil {
+		logger.Warn("error set new query limit", zap.Error(err))
+		return nil, err
+	}
+	s := fmt.Sprintf("new query limit version %d", version)
+	return []byte(s), nil
+}


### PR DESCRIPTION
Wasn't able to update query limits and it caused rule eval failures. Did apply changes and restarted m3db or m3 operator and m3 crd is updated as well, non worked out. Had to modify this value by some programmatic tool.

```
~/repos/m3 (query-limits) $  bin/m3ctl get limits --endpoint localhost:2379
2023-08-06T21:33:05.043-0700	INFO	etcd/etcd.go:51	output	{"proto": "maxRecentlyQueriedSeriesDiskBytesRead:<limit:400000000 lookbackSeconds:15 > "}
400000000
~/repos/m3 (query-limits) $ bin/m3ctl update  --endpoint localhost:2379 -q 800000000
new query limit version 4
~/repos/m3 (query-limits) $ bin/m3ctl get limits --endpoint localhost:2379
2023-08-06T21:42:39.655-0700	INFO	etcd/etcd.go:51	output	{"proto": "maxRecentlyQueriedSeriesDiskBytesRead:<limit:800000000 lookbackSeconds:15 > "}
800000000
~/repos/m3 (query-limits) $ klgf m3db-rep0-0 | grep disk-bytes-read
{"level":"info","ts":"2023-08-04T01:15:36.743Z","msg":"query limit interval started","name":"disk-bytes-read"}
{"level":"info","ts":"2023-08-04T01:17:22.829Z","msg":"query limit options updated","name":"disk-bytes-read","new":{"Limit":400000000,"Lookback":15000000000,"ForceExceeded":false,"ForceWaited":false},"old":{"Limit":800000000,"Lookback":15000000000,"ForceExceeded":false,"ForceWaited":false}}
{"level":"info","ts":"2023-08-07T04:42:31.060Z","msg":"query limit options updated","name":"disk-bytes-read","new":{"Limit":800000000,"Lookback":15000000000,"ForceExceeded":false,"ForceWaited":false},"old":{"Limit":400000000,"Lookback":15000000000,"ForceExceeded":false,"ForceWaited":false}}
```