### PR TITLE
[PLAT-92127] refactor tenant attribution to avoid weird tenants

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -847,8 +847,8 @@ type PrometheusRemoteBackendConfiguration struct {
 	KeepAlive       *time.Duration                                 `yaml:"keepAlive"`
 	IdleConnTimeout *time.Duration                                 `yaml:"idleConnTimeout"`
 	MaxIdleConns    *int                                           `yaml:"maxIdleConns"`
-	QueueSize       *int                                           `yaml:"queueSize"`
-	PoolSize        *int                                           `yaml:"poolSize"`
+	QueueSize       int                                            `yaml:"queueSize" validate:"min=1"`
+	PoolSize        int                                            `yaml:"poolSize" validate:"min=1"`
 	TickDuration    *time.Duration                                 `yaml:"tickDuration"`
 }
 

--- a/src/query/storage/promremote/query_coverter.go
+++ b/src/query/storage/promremote/query_coverter.go
@@ -34,7 +34,7 @@ var errNilQuery = errors.New("received nil query or no samples in query")
 
 func convertAndEncodeWriteQuery(queries []*storage.WriteQuery) ([]byte, error) {
 	promQuery := convertWriteQuery(queries)
-	if len(promQuery.Timeseries) == 0 {
+	if promQuery == nil || len(promQuery.Timeseries) == 0 {
 		return []byte{}, errNilQuery
 	}
 	data, err := promQuery.Marshal()
@@ -45,6 +45,9 @@ func convertAndEncodeWriteQuery(queries []*storage.WriteQuery) ([]byte, error) {
 }
 
 func convertWriteQuery(queries []*storage.WriteQuery) *prompb.WriteRequest {
+	if queries == nil || len(queries) == 0 {
+		return nil
+	}
 	ts := make([]prompb.TimeSeries, 0, len(queries))
 	for _, query := range queries {
 		if query == nil || len(query.Datapoints()) == 0 {


### PR DESCRIPTION
This is to fix sometimes the tenant key got corrupted due to the requests can set abritrary values, now tenant has to be pre-defined and fixed.

<img width="832" alt="Screenshot 2023-10-03 at 7 12 22 PM" src="https://github.com/databricks/m3/assets/96499497/c0f62ec2-1032-45a2-99fd-76e6e9db2e6a">

Added unit tests.

```
GOROOT=/usr/local/opt/go/libexec #gosetup
GOPATH=/Users/yi.jin/go #gosetup
/usr/local/opt/go/libexec/bin/go test -c -o /private/var/folders/7w/bk4g23r116j_srlrlf8_ys7r0000gp/T/GoLand/___go_test_github_com_m3db_m3_src_query_storage_promremote.test github.com/m3db/m3/src/query/storage/promremote #gosetup
/usr/local/opt/go/libexec/bin/go tool test2json -t /private/var/folders/7w/bk4g23r116j_srlrlf8_ys7r0000gp/T/GoLand/___go_test_github_com_m3db_m3_src_query_storage_promremote.test -test.v -test.paniconexit0
=== RUN   TestNewFromConfiguration
--- PASS: TestNewFromConfiguration (0.00s)
=== RUN   TestTenantRules
--- PASS: TestTenantRules (0.00s)
=== RUN   TestUnaggregatedEndpoint
--- PASS: TestUnaggregatedEndpoint (0.00s)
=== RUN   TestDefaultDownsampleAll
--- PASS: TestDefaultDownsampleAll (0.00s)
=== RUN   TestHTTPDefaults
--- PASS: TestHTTPDefaults (0.00s)
=== RUN   TestValidation
--- PASS: TestValidation (0.00s)
=== RUN   TestValidation/can't_be_nil
    --- PASS: TestValidation/can't_be_nil (0.00s)
=== RUN   TestValidation/at_least_1_endpoint
    --- PASS: TestValidation/at_least_1_endpoint (0.00s)
=== RUN   TestValidation/valid_endpoint
    --- PASS: TestValidation/valid_endpoint (0.00s)
=== RUN   TestValidation/name_required_for_endpoint
    --- PASS: TestValidation/name_required_for_endpoint (0.00s)
=== RUN   TestValidation/name_must_be_unique
    --- PASS: TestValidation/name_must_be_unique (0.00s)
=== RUN   TestValidation/non_negative_keep_alive
    --- PASS: TestValidation/non_negative_keep_alive (0.00s)
=== RUN   TestValidation/non_negative_max_idle_conns
    --- PASS: TestValidation/non_negative_max_idle_conns (0.00s)
=== RUN   TestValidation/non_negative_idle_conn_timeout
    --- PASS: TestValidation/non_negative_idle_conn_timeout (0.00s)
=== RUN   TestValidation/non_negative_request_timeout
    --- PASS: TestValidation/non_negative_request_timeout (0.00s)
=== RUN   TestValidation/non_negative_connect_timeout
    --- PASS: TestValidation/non_negative_connect_timeout (0.00s)
=== RUN   TestValidateEndpoint
--- PASS: TestValidateEndpoint (0.00s)
=== RUN   TestValidateEndpoint/address_required
    --- PASS: TestValidateEndpoint/address_required (0.00s)
=== RUN   TestValidateEndpoint/address_spaces_trimmed
    --- PASS: TestValidateEndpoint/address_spaces_trimmed (0.00s)
=== RUN   TestValidateEndpoint/storage_policy_is_optional
    --- PASS: TestValidateEndpoint/storage_policy_is_optional (0.00s)
=== RUN   TestValidateEndpoint/retention_must_be_positive
    --- PASS: TestValidateEndpoint/retention_must_be_positive (0.00s)
=== RUN   TestValidateEndpoint/resolution_must_be_positive
    --- PASS: TestValidateEndpoint/resolution_must_be_positive (0.00s)
=== RUN   TestValidateEndpoint/tenant_header_must_be_set
    --- PASS: TestValidateEndpoint/tenant_header_must_be_set (0.00s)
=== RUN   TestWriteQueryConverter
--- PASS: TestWriteQueryConverter (0.00s)
=== RUN   TestWriteQueryConverter/single_datapoint
    --- PASS: TestWriteQueryConverter/single_datapoint (0.00s)
=== RUN   TestWriteQueryConverter/duplicate_tags_and_samples
    --- PASS: TestWriteQueryConverter/duplicate_tags_and_samples (0.00s)
=== RUN   TestWriteQueryConverter/overrides_metric_name_tag
    --- PASS: TestWriteQueryConverter/overrides_metric_name_tag (0.00s)
=== RUN   TestWriteQueryConverter/overrides_bucket_name_name_tag
    --- PASS: TestWriteQueryConverter/overrides_bucket_name_name_tag (0.00s)
=== RUN   TestConvertQueryNil
--- PASS: TestConvertQueryNil (0.00s)
=== RUN   TestEncodeWriteQuery
--- PASS: TestEncodeWriteQuery (0.00s)
=== RUN   TestWrite
2023-10-06T11:40:11.093-0700	INFO	promremote/storage.go:216	Start prometheus remote write storage async job	{"queueSize": 1, "poolSize": 1}
--- PASS: TestWrite (0.20s)
=== RUN   TestWriteBasedOnRetention
2023-10-06T11:40:11.295-0700	INFO	promremote/storage.go:216	Start prometheus remote write storage async job	{"queueSize": 9, "poolSize": 1}
--- PASS: TestWriteBasedOnRetention (9.74s)
=== RUN   TestWriteBasedOnRetention/send_short_retention_write
2023-10-06T11:40:11.394-0700	INFO	promremote/storage.go:265	attempt to exit async go routine
2023-10-06T11:40:11.395-0700	INFO	promremote/storage.go:270	successfully exit due to graceful shutdown
    --- PASS: TestWriteBasedOnRetention/send_short_retention_write (2.60s)
=== RUN   TestWriteBasedOnRetention/send_medium_retention_write
    --- PASS: TestWriteBasedOnRetention/send_medium_retention_write (2.00s)
=== RUN   TestWriteBasedOnRetention/send_write_to_multiple_instances_configured_with_same_retention
    --- PASS: TestWriteBasedOnRetention/send_write_to_multiple_instances_configured_with_same_retention (2.01s)
=== RUN   TestWriteBasedOnRetention/send_unconfigured_retention_write
2023-10-06T11:40:17.911-0700	ERROR	promremote/storage.go:233	no pre-defined tenant found, dropping it	{"tenant": "unknown", "attributes": "type=unknown, retention=720h0m0s, resolution=5m0.000000001s", "defaultTenant": "unknown", "timeseries": "{test_tag_name=\"test_tag_value\"}"}
github.com/m3db/m3/src/query/storage/promremote.(*promStorage).startAsync.func1
	/Users/yi.jin/repos/m3/src/query/storage/promremote/storage.go:233
2023-10-06T11:40:17.911-0700	ERROR	promremote/storage.go:233	no pre-defined tenant found, dropping it	{"tenant": "unknown", "attributes": "type=unknown, retention=720h0m0.000000001s, resolution=5m0s", "defaultTenant": "unknown", "timeseries": "{test_tag_name=\"test_tag_value\"}"}
github.com/m3db/m3/src/query/storage/promremote.(*promStorage).startAsync.func1
	/Users/yi.jin/repos/m3/src/query/storage/promremote/storage.go:233
    --- PASS: TestWriteBasedOnRetention/send_unconfigured_retention_write (3.02s)
=== RUN   TestWriteBasedOnRetention/error_should_not_prevent_sending_to_other_instances
2023-10-06T11:40:20.996-0700	ERROR	promremote/storage.go:105	error writing async batch	{"tenant": "unknown", "error": "expected status code 2XX: actual=500, address=http://127.0.0.1:50098/write, resp=test err\n", "errorCauses": [{"error": "expected status code 2XX: actual=500, address=http://127.0.0.1:50098/write, resp=test err\n"}]}
github.com/m3db/m3/src/query/storage/promremote.(*WriteQueue).Flush
	/Users/yi.jin/repos/m3/src/query/storage/promremote/storage.go:105
github.com/m3db/m3/src/query/storage/promremote.(*promStorage).startAsync.func1.2
	/Users/yi.jin/repos/m3/src/query/storage/promremote/storage.go:261
github.com/m3db/m3/src/x/sync.(*workerPool).GoInstrument.func1
	/Users/yi.jin/repos/m3/src/x/sync/worker_pool.go:55
    --- PASS: TestWriteBasedOnRetention/error_should_not_prevent_sending_to_other_instances (0.10s)
=== RUN   TestNamespaces
--- PASS: TestNamespaces (0.00s)
=== RUN   TestNamespaces/raw
    --- PASS: TestNamespaces/raw (0.00s)
=== RUN   TestNamespaces/donwsampled
    --- PASS: TestNamespaces/donwsampled (0.00s)
=== RUN   TestNamespaces/donwsampled_all_false
    --- PASS: TestNamespaces/donwsampled_all_false (0.00s)
=== RUN   TestNewSessionPanics
--- PASS: TestNewSessionPanics (0.00s)
PASS

Process finished with the exit code 0
```
