### PR TITLE
Fix POST query_range request shadowing

### DIFF
--- a/src/query/api/v1/handler/prom/read.go
+++ b/src/query/api/v1/handler/prom/read.go
@@ -186,7 +186,13 @@ func (h* readHandler) sendShadowQuery(r *http.Request) {
 	if r.URL.RawQuery != "" {
 		shadowURL += "?" + r.URL.RawQuery
 	}
-	shadowReq, err := http.NewRequest(r.Method, shadowURL, r.Body)
+	var requestBody io.Reader = r.Body
+	if r.Method == "POST" {
+		// If it's a POST request, r.Body has already been read and parsed into r.PostForm.
+		// r.Body can't be parsed twice.
+		requestBody = strings.NewReader(r.PostForm.Encode())
+	}
+	shadowReq, err := http.NewRequest(r.Method, shadowURL, requestBody)
 	if err != nil {
 		h.logger.Error("Failed to create a shadow http request", zap.Error(err), zap.String("shadowURL", shadowURL))
 		h.qs.skippedQueryCounter.Inc(1)


### PR DESCRIPTION
As the title.
Deployed the dev-dev image to `dev-aws-us-west-2`.
```
[dev-aws-us-west-2] [m3] [m3coord-read-regional-deployment-f9484654-tclz9] > logs | rg 'query_range'
[dev-aws-us-west-2] [m3] [m3coord-read-regional-deployment-f9484654-tclz9] > 1
[dev-aws-us-west-2] [m3] [m3coord-read-regional-deployment-f9484654-x5lhb] > logs | rg 'query_range'
[dev-aws-us-west-2] [m3] [m3coord-read-regional-deployment-f9484654-x5lhb] >
```