### PR TITLE
Introduce `increasev2` transform to pre-aggregation

### DIFF
--- a/src/metrics/generated/proto/transformationpb/transformation.pb.go
+++ b/src/metrics/generated/proto/transformationpb/transformation.pb.go
@@ -49,12 +49,13 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 type TransformationType int32
 
 const (
-	TransformationType_UNKNOWN   TransformationType = 0
-	TransformationType_ABSOLUTE  TransformationType = 1
-	TransformationType_PERSECOND TransformationType = 2
-	TransformationType_INCREASE  TransformationType = 3
-	TransformationType_ADD       TransformationType = 4
-	TransformationType_RESET     TransformationType = 5
+	TransformationType_UNKNOWN     TransformationType = 0
+	TransformationType_ABSOLUTE    TransformationType = 1
+	TransformationType_PERSECOND   TransformationType = 2
+	TransformationType_INCREASE    TransformationType = 3
+	TransformationType_ADD         TransformationType = 4
+	TransformationType_RESET       TransformationType = 5
+	TransformationType_INCREASEV2  TransformationType = 6
 )
 
 var TransformationType_name = map[int32]string{
@@ -64,14 +65,16 @@ var TransformationType_name = map[int32]string{
 	3: "INCREASE",
 	4: "ADD",
 	5: "RESET",
+	6: "INCREASEV2",
 }
 var TransformationType_value = map[string]int32{
-	"UNKNOWN":   0,
-	"ABSOLUTE":  1,
-	"PERSECOND": 2,
-	"INCREASE":  3,
-	"ADD":       4,
-	"RESET":     5,
+	"UNKNOWN":     0,
+	"ABSOLUTE":    1,
+	"PERSECOND":   2,
+	"INCREASE":    3,
+	"ADD":         4,
+	"RESET":       5,
+	"INCREASEV2":  6,
 }
 
 func (x TransformationType) String() string {

--- a/src/metrics/generated/proto/transformationpb/transformation.proto
+++ b/src/metrics/generated/proto/transformationpb/transformation.proto
@@ -31,4 +31,5 @@ enum TransformationType {
   INCREASE = 3;
   ADD = 4;
   RESET = 5;
+  INCREASEV2 = 6;
 }

--- a/src/metrics/transformation/binary.go
+++ b/src/metrics/transformation/binary.go
@@ -34,6 +34,7 @@ var (
 	// taking reference to it each time when converting to iface).
 	transformPerSecondFn = BinaryTransformFn(perSecond)
 	transformIncreaseFn  = BinaryTransformFn(increase)
+	transformIncreasev2Fn  = BinaryTransformFn(increasev2)
 )
 
 func transformPerSecond() BinaryTransform {
@@ -62,6 +63,11 @@ func transformIncrease() BinaryTransform {
 	return transformIncreaseFn
 }
 
+func transformIncreasev2() BinaryTransform {
+	return transformIncreasev2Fn
+}
+
+
 // increase computes the difference between consecutive datapoints, unlike
 // perSecond it does not account for the time interval between the values.
 // Note:
@@ -85,4 +91,12 @@ func increase(prev, curr Datapoint, _ FeatureFlags) Datapoint {
 		return emptyDatapoint
 	}
 	return Datapoint{TimeNanos: curr.TimeNanos, Value: diff}
+}
+
+// increasev2 treats a NaN prev as curr. That's the only difference between increase and increasev2.
+func increasev2(prev, curr Datapoint, ff FeatureFlags) Datapoint {
+	if math.IsNaN(prev.Value) {
+		prev.Value = curr.Value
+	}
+	return increase(prev, curr, ff)
 }

--- a/src/metrics/transformation/binary_test.go
+++ b/src/metrics/transformation/binary_test.go
@@ -79,3 +79,30 @@ func TestPerSecond(t *testing.T) {
 		}
 	}
 }
+
+func TestIncrease(t *testing.T) {
+	inputs := []struct {
+		prev        Datapoint
+		curr        Datapoint
+		expected    Datapoint
+		expected2   Datapoint
+	}{
+		{
+			prev:      Datapoint{TimeNanos: time.Unix(1230, 0).UnixNano(), Value: 25},
+			curr:      Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 30},
+			expected:  Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 5},
+			expected2: Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 5},
+		},
+		{
+			prev:        Datapoint{TimeNanos: time.Unix(1230, 0).UnixNano(), Value: math.NaN()},
+			curr:        Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 20},
+			expected:    Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 20},
+			expected2:   Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 0},
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, increase(input.prev, input.curr, FeatureFlags{}))
+		require.Equal(t, input.expected2, increasev2(input.prev, input.curr, FeatureFlags{}))
+	}
+}

--- a/src/metrics/transformation/type.go
+++ b/src/metrics/transformation/type.go
@@ -41,11 +41,12 @@ const (
 	Increase
 	Add
 	Reset
+	Increasev2
 )
 
 const (
 	_minValidTransformationType = Absolute
-	_maxValidTransformationType = Reset
+	_maxValidTransformationType = Increasev2
 )
 
 // IsValid checks if the transformation type is valid.
@@ -265,6 +266,7 @@ var (
 	binaryTransforms = map[Type]func() BinaryTransform{
 		PerSecond: transformPerSecond,
 		Increase:  transformIncrease,
+		Increasev2:  transformIncreasev2,
 	}
 	unaryMultiOutputTransforms = map[Type]func() UnaryMultiOutputTransform{
 		Reset: transformReset,

--- a/src/metrics/transformation/type_string.go
+++ b/src/metrics/transformation/type_string.go
@@ -34,11 +34,12 @@ func _() {
 	_ = x[Increase-3]
 	_ = x[Add-4]
 	_ = x[Reset-5]
+	_ = x[Increasev2-6]
 }
 
-const _Type_name = "UnknownTypeAbsolutePerSecondIncreaseAddReset"
+const _Type_name = "UnknownTypeAbsolutePerSecondIncreaseAddResetIncreasev2"
 
-var _Type_index = [...]uint8{0, 11, 19, 28, 36, 39, 44}
+var _Type_index = [...]uint8{0, 11, 19, 28, 36, 39, 44, 54}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
# The issue
In counter pre-aggregation, `increase` is applied to all original counters. If an original counter is new (e.g., a pod moved to another node), `increase()` is applied to the first data sample of the new counter with a `NaN` as the previous value. `increase` treats `NaN` as 0 and returns a big diff. `increasev2` treats `NaN` as the current value to fix this issue.

This `increase` behavior creates a discrepancy between two query results, `sum(increase(original_counter[3m]))` and `increase(aggregated_counter[3m])`. 

Here is an example
```
======= time -----> ===============
counter_0 = [0,     2,    4,    6]
counter_1  = [NaN, 10,  11,   12]

increase(counter_0[]) = [0,       2,    2,   2]
increase(countter_1[]) = [NaN,  10, 1,  1]

aggregated_counter = [0, 12, 15, 18]

increase(aggregated_counter[]) = [0, 12, 3, 3]

sum(increase(counter_*[])) = [0, 2, 3, 3]
```

`increasev2` will be used in this proposal: https://docs.google.com/document/d/1JBt05LFVZ_l0oUj44D4TnXeQmelj8L5QEekxoAX4EAM/edit

<img width="892" alt="image" src="https://github.com/databricks/m3/assets/129140017/9b2e02d6-053a-496e-a560-1bc1a31a3e9e">
<img width="740" alt="image" src="https://github.com/databricks/m3/assets/129140017/a5dd1255-93ee-4371-afe4-f2002f8b7dcb">


# Tests & Build

```
make m3coordinator


$ go test -timeout 30s -run ^(TestPerSecond|TestIncrease)$ github.com/m3db/m3/src/metrics/transformation

ok  	github.com/m3db/m3/src/metrics/transformation	0.198s

$ grep '"Increasev2"' ~/data/m3coord.yaml
          "type": "Increasev2"

$ bin/m3coordinator -f ~/data/m3coord.yaml -z
2024/04/03 19:28:21 Go Runtime version: go1.22.0
2024/04/03 19:28:21 Build Version:      v1.5.0
2024/04/03 19:28:21 Build Revision:     93f6625a6
2024/04/03 19:28:21 Build Branch:       increase_v2
2024/04/03 19:28:21 Build Date:         2024-04-03-19:28:10
2024/04/03 19:28:21 Build TimeUnix:     1712197690
2024/04/03 19:28:21 the config is valid.
```