### PR TITLE
Simplify and fix Pantheon async writer

### DIFF
--- a/src/query/storage/promremote/storage.go
+++ b/src/query/storage/promremote/storage.go
@@ -70,12 +70,17 @@ func NewWriteQueue(t tenant, capacity int) *WriteQueue {
 	}
 }
 
-func (wq *WriteQueue) pop() []*storage.WriteQuery {
-	wq.Lock()
-	defer wq.Unlock()
+// This one can only be called with the lock held by the call site.
+func (wq *WriteQueue) popUnderLock() []*storage.WriteQuery {
 	res := wq.queries
 	wq.queries = make([]*storage.WriteQuery, 0, wq.capacity)
 	return res
+}
+
+func (wq *WriteQueue) pop() []*storage.WriteQuery {
+	wq.Lock()
+	defer wq.Unlock()
+	return wq.popUnderLock()
 }
 
 func (wq *WriteQueue) Len() int {
@@ -85,11 +90,15 @@ func (wq *WriteQueue) Len() int {
 }
 
 func (wq *WriteQueue) Add(query *storage.WriteQuery) []*storage.WriteQuery {
-	if wq.Len() >= wq.capacity {
-		return wq.pop()
-	}
 	wq.Lock()
 	defer wq.Unlock()
+	// We can probably optimize lock contention for the case where the queue is full,
+	// but the majority of the time it won't be full and therefore not worth optimizating.
+	// NB: we have to check if the queue is full under the lock. Otherwise, two goroutines
+	// may see the full queue and try to pop it at the same time.
+	if len(wq.queries) >= wq.capacity {
+		return wq.popUnderLock()
+	}
 	wq.queries = append(wq.queries, query)
 	return nil
 }
@@ -166,6 +175,7 @@ func NewStorage(opts Options) (storage.Storage, error) {
 		droppedWrites:   scope.Counter("dropped_writes"),
 		enqueued:        scope.Counter("enqueued"),
 		batchWrite:      scope.Counter("batch_write"),
+		batchWriteErr:   scope.Counter("batch_write_err"),
 		tickWrite:       scope.Counter("tick_write"),
 		logger:          opts.logger,
 		queryQueue:      make(chan *storage.WriteQuery, opts.queueSize),
@@ -187,6 +197,7 @@ type promStorage struct {
 	droppedWrites   tally.Counter
 	enqueued        tally.Counter
 	batchWrite      tally.Counter
+	batchWriteErr   tally.Counter
 	tickWrite       tally.Counter
 	logger          *zap.Logger
 	queryQueue      chan *storage.WriteQuery
@@ -216,62 +227,83 @@ func (p *promStorage) getTenant(query *storage.WriteQuery) tenant {
 	}
 }
 
+func (p *promStorage) flushPendingQueues(minQueueSizeToFlush int, ctx context.Context, wg *sync.WaitGroup) {
+	for t, queue := range p.pendingQuery {
+		if queue.Len() < minQueueSizeToFlush {
+			if queue.Len() != 0 {
+				p.logger.Warn("don't do tick flush for small batch",
+					zap.String("tenant", t.name),
+					zap.Int("size", queue.Len()),
+					zap.Int("queue size", p.opts.queueSize))
+			}
+			continue
+		}
+		wg.Add(1)
+		p.workerPool.Go(func() {
+			queue.Flush(ctx, p)
+			wg.Done()
+		})
+	}
+}
+
+func (p *promStorage) writeLoop(ctx context.Context) {
+	ctxForWrites, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// This loop ensures that all pending writes are flushed before exiting and after `ctx` is done.
+	var wg sync.WaitGroup
+	p.workerPool.Init()
+	ticker := time.NewTicker(*p.opts.tickDuration)
+	for {
+		select {
+		case query := <-p.queryQueue:
+			if query == nil {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			t := p.getTenant(query)
+			if _, ok := p.pendingQuery[t]; !ok {
+				p.noTenantFound.Inc(1)
+				p.droppedWrites.Inc(1)
+				p.logger.Error("no pre-defined tenant found, dropping it",
+					zap.String("tenant", t.name), zap.Any("attributes", t.attr),
+					zap.String("defaultTenant", p.opts.tenantDefault),
+					zap.String("timeseries", query.String()))
+				continue
+			}
+			if dataBatch := p.pendingQuery[t].Add(query); dataBatch != nil {
+				p.batchWrite.Inc(int64(len(dataBatch)))
+				wg.Add(1)
+				p.workerPool.Go(func() {
+					defer wg.Done()
+					if err := p.writeBatch(ctxForWrites, t, dataBatch); err != nil {
+						p.logger.Error("error writing async batch",
+							zap.String("tenant", t.name),
+							zap.Error(err))
+					}
+				})
+			}
+		case <-ticker.C:
+			p.flushPendingQueues(p.opts.queueSize/10, ctxForWrites, &wg)
+		case <-ctx.Done():
+			p.logger.Info("The context is done. Flushing pending writes.",
+				zap.Int("num_queues", len(p.pendingQuery)),
+			)
+			p.flushPendingQueues(0, ctxForWrites, &wg)
+			// Block until all pending writes are flushed because we don't want to lose any data.
+			wg.Wait()
+			p.logger.Info("successfully exit after flushing pending writes")
+			return
+		}
+	}
+}
+
 func (p *promStorage) startAsync(ctx context.Context) {
 	p.logger.Info("Start prometheus remote write storage async job",
 		zap.Int("queueSize", p.opts.queueSize),
 		zap.Int("poolSize", p.opts.poolSize))
-	p.workerPool.Init()
-	ticker := time.NewTicker(*p.opts.tickDuration)
 	go func() {
-		for {
-			select {
-			case query := <-p.queryQueue:
-				if query == nil {
-					time.Sleep(100 * time.Millisecond)
-					continue
-				}
-				t := p.getTenant(query)
-				if _, ok := p.pendingQuery[t]; !ok {
-					p.noTenantFound.Inc(1)
-					p.droppedWrites.Inc(1)
-					p.logger.Error("no pre-defined tenant found, dropping it",
-						zap.String("tenant", t.name), zap.Any("attributes", t.attr),
-						zap.String("defaultTenant", p.opts.tenantDefault),
-						zap.String("timeseries", query.String()))
-					continue
-				}
-				if dataBatch := p.pendingQuery[t].Add(query); dataBatch != nil {
-					p.batchWrite.Inc(int64(len(dataBatch)))
-					p.workerPool.Go(func() {
-						if err := p.writeBatch(ctx, t, dataBatch); err != nil {
-							p.logger.Error("error writing async batch",
-								zap.String("tenant", t.name),
-								zap.Error(err))
-						}
-					})
-				}
-			case <-ticker.C:
-				for t, queue := range p.pendingQuery {
-					if queue.Len() <= p.opts.queueSize/10 {
-						if queue.Len() != 0 {
-							p.logger.Warn("don't do tick flush for small batch",
-								zap.String("tenant", t.name),
-								zap.Int("size", queue.Len()),
-								zap.Int("queue size", p.opts.queueSize))
-						}
-						continue
-					}
-					p.workerPool.Go(func() {
-						queue.Flush(ctx, p)
-					})
-				}
-			case <-ctx.Done():
-				p.logger.Info("attempt to exit async go routine")
-				goto exit
-			}
-		}
-	exit:
-		p.logger.Info("successfully exit due to graceful shutdown")
+		p.logger.Info("Starting the write loop")
+		p.writeLoop(ctx)
 	}()
 }
 
@@ -297,45 +329,15 @@ func (p *promStorage) writeBatch(ctx context.Context, tenant tenant, queries []*
 		return err
 	}
 
-	var wg sync.WaitGroup
-	multiErr := xerrors.NewMultiError()
-	var errLock sync.Mutex
-	atLeastOneEndpointMatched := false
-	for _, endpoint := range p.opts.endpoints {
-		endpoint := endpoint
-		if endpoint.attributes.Resolution != tenant.attr.Resolution ||
-			endpoint.attributes.Retention != tenant.attr.Retention {
-			continue
-		}
-
-		metrics := p.endpointMetrics[endpoint.name]
-		atLeastOneEndpointMatched = true
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := p.write(ctx, metrics, endpoint, tenant, bytes.NewReader(encoded))
-			if err != nil {
-				errLock.Lock()
-				multiErr = multiErr.Add(err)
-				errLock.Unlock()
-				return
-			}
-		}()
+	// We only write to the first endpoint since this storage(Panthoen) doesn't distinguish raw data samples
+	// from aggregated ones.
+	endpoint := p.opts.endpoints[0]
+	metrics := p.endpointMetrics[endpoint.name]
+	err = p.write(ctx, metrics, endpoint, tenant, bytes.NewReader(encoded))
+	if err != nil {
+		p.batchWriteErr.Inc(int64(len(queries)))
 	}
-
-	wg.Wait()
-
-	if !atLeastOneEndpointMatched {
-		p.droppedWrites.Inc(1)
-		multiErr = multiErr.Add(errNoEndpoints)
-		p.logger.Warn(
-			"write did not match any of known endpoints",
-			zap.Duration("retention", tenant.attr.Retention),
-			zap.Duration("resolution", tenant.attr.Resolution),
-		)
-	}
-	return multiErr.FinalError()
+	return err
 }
 
 func (p *promStorage) Type() storage.Type {
@@ -343,12 +345,9 @@ func (p *promStorage) Type() storage.Type {
 }
 
 func (p *promStorage) Close() error {
-	close(p.queryQueue)
+	// This cancel will be blocked on flushing all pending writes.
 	p.cancel()
-	ctx := context.Background()
-	for _, queries := range p.pendingQuery {
-		queries.Flush(ctx, p)
-	}
+	// After this point, all writes are flushed or errored out.
 	p.client.CloseIdleConnections()
 	return nil
 }

--- a/src/query/storage/promremote/storage_test.go
+++ b/src/query/storage/promremote/storage_test.go
@@ -100,12 +100,8 @@ func TestWrite(t *testing.T) {
 	assert.Equal(t, expectedSample, promWrite.Timeseries[0].Samples[0])
 
 	tallytest.AssertCounterValue(
-		t, 1, scope.Snapshot(), "test_scope.prom_remote_storage.writeSingle.success",
-		map[string]string{"endpoint_name": "testEndpoint"},
-	)
-	tallytest.AssertCounterValue(
-		t, 0, scope.Snapshot(), "test_scope.prom_remote_storage.writeSingle.errors",
-		map[string]string{"endpoint_name": "testEndpoint"},
+		t, 1, scope.Snapshot(), "test_scope.prom_remote_storage.write.total",
+		map[string]string{"endpoint_name": "testEndpoint", "code": "200"},
 	)
 }
 
@@ -139,43 +135,50 @@ func TestWriteBasedOnRetention(t *testing.T) {
 		Resolution: 10 * time.Minute,
 		Retention:  8760 * time.Hour,
 	}
-	promStorage, err := NewStorage(Options{
-		endpoints: []EndpointOptions{
-			{
-				address:      promShortRetention.WriteAddr(),
-				attributes:   shortRetentionAttr,
-				tenantHeader: "TENANT",
+	getPromStorage := func() storage.Storage {
+		promStorage, err := NewStorage(Options{
+			endpoints: []EndpointOptions{
+				// always write to the first endpoint
+				{
+					address:      promShortRetention.WriteAddr(),
+					attributes:   shortRetentionAttr,
+					tenantHeader: "TENANT",
+				},
+				{
+					address:      promMediumRetention.WriteAddr(),
+					attributes:   mediumRetentionAttr,
+					tenantHeader: "TENANT",
+				},
+				{
+					address:      promLongRetention.WriteAddr(),
+					attributes:   longRetentionAttr,
+					tenantHeader: "TENANT",
+				},
+				{
+					address:      promLongRetention2.WriteAddr(),
+					attributes:   longRetentionAttr,
+					tenantHeader: "TENANT",
+				},
 			},
-			{
-				address:      promMediumRetention.WriteAddr(),
-				attributes:   mediumRetentionAttr,
-				tenantHeader: "TENANT",
-			},
-			{
-				address:      promLongRetention.WriteAddr(),
-				attributes:   longRetentionAttr,
-				tenantHeader: "TENANT",
-			},
-			{
-				address:      promLongRetention2.WriteAddr(),
-				attributes:   longRetentionAttr,
-				tenantHeader: "TENANT",
-			},
-		},
-		poolSize:      1,
-		queueSize:     9,
-		scope:         scope,
-		logger:        logger,
-		tenantDefault: "unknown",
-		tickDuration:  ptrDuration(tickDuration),
-	})
-	require.NoError(t, err)
-	defer closeWithCheck(t, promStorage)
-
+			poolSize:      1,
+			queueSize:     9,
+			scope:         scope,
+			logger:        logger,
+			tenantDefault: "unknown",
+			tickDuration:  ptrDuration(tickDuration),
+		})
+		require.NoError(t, err)
+		return promStorage
+	}
 	t.Run("send short retention write", func(t *testing.T) {
 		reset()
+		promStorage := getPromStorage()
 		err := writeTestMetric(t, promStorage, shortRetentionAttr)
 		require.NoError(t, err)
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
 		assert.NotNil(t, getWriteRequest(promShortRetention))
 		assert.Nil(t, getWriteRequest(promMediumRetention))
 		assert.Nil(t, getWriteRequest(promLongRetention))
@@ -183,25 +186,34 @@ func TestWriteBasedOnRetention(t *testing.T) {
 
 	t.Run("send medium retention write", func(t *testing.T) {
 		reset()
+		promStorage := getPromStorage()
 		err := writeTestMetric(t, promStorage, mediumRetentionAttr)
 		require.NoError(t, err)
-		assert.Nil(t, getWriteRequest(promShortRetention))
-		assert.NotNil(t, getWriteRequest(promMediumRetention))
-		assert.Nil(t, getWriteRequest(promLongRetention))
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
+		assert.NotNil(t, getWriteRequest(promShortRetention))
 	})
 
 	t.Run("send write to multiple instances configured with same retention", func(t *testing.T) {
 		reset()
+		promStorage := getPromStorage()
 		err := writeTestMetric(t, promStorage, longRetentionAttr)
 		require.NoError(t, err)
-		assert.Nil(t, getWriteRequest(promShortRetention))
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
+		assert.NotNil(t, getWriteRequest(promShortRetention))
 		assert.Nil(t, getWriteRequest(promMediumRetention))
-		assert.NotNil(t, getWriteRequest(promLongRetention))
-		assert.NotNil(t, getWriteRequest(promLongRetention2))
+		assert.Nil(t, getWriteRequest(promLongRetention))
+		assert.Nil(t, getWriteRequest(promLongRetention2))
 	})
 
 	t.Run("send unconfigured retention write", func(t *testing.T) {
 		reset()
+		promStorage := getPromStorage()
 		writeTestMetric(t, promStorage, storagemetadata.Attributes{
 			Resolution: mediumRetentionAttr.Resolution + 1,
 			Retention:  mediumRetentionAttr.Retention,
@@ -210,6 +222,11 @@ func TestWriteBasedOnRetention(t *testing.T) {
 			Resolution: mediumRetentionAttr.Resolution,
 			Retention:  mediumRetentionAttr.Retention + 1,
 		})
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
+		// All writes get dropped because of "no pre-defined tenant found"
 		assert.Nil(t, getWriteRequest(promShortRetention))
 		assert.Nil(t, getWriteRequest(promMediumRetention))
 		assert.Nil(t, getWriteRequest(promLongRetention))
@@ -219,13 +236,17 @@ func TestWriteBasedOnRetention(t *testing.T) {
 
 	t.Run("error should not prevent sending to other instances", func(t *testing.T) {
 		reset()
+		promStorage := getPromStorage()
 		promLongRetention.SetError("test err", http.StatusInternalServerError)
 		writeTestMetric(t, promStorage, longRetentionAttr)
-		assert.NotNil(t, getWriteRequest(promLongRetention2))
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
+		assert.NotNil(t, getWriteRequest(promShortRetention))
 	})
 }
 
-/* Disable error handling as everything is async to group by tenants according to rules
 func TestErrorHandling(t *testing.T) {
 	svr := promremotetest.NewServer(t)
 	defer svr.Close()
@@ -235,35 +256,64 @@ func TestErrorHandling(t *testing.T) {
 		Retention:   720 * time.Hour,
 		Resolution:  5 * time.Minute,
 	}
-	promStorage, err := NewStorage(Options{
-		endpoints:     []EndpointOptions{{address: svr.WriteAddr(), attributes: attr, tenantHeader: "TENANT"}},
-		poolSize:      1,
-		queueSize:     1,
-		scope:         scope,
-		logger:        logger,
-		tenantDefault: "unknown",
-		tickDuration:  ptrDuration(tickDuration),
-	})
-	require.NoError(t, err)
-	defer closeWithCheck(t, promStorage)
+	getPromStorage := func(scope tally.Scope) storage.Storage {
+		promStorage, err := NewStorage(Options{
+			endpoints:     []EndpointOptions{{name: "testEndpoint", address: svr.WriteAddr(), attributes: attr, tenantHeader: "TENANT"}},
+			poolSize:      1,
+			queueSize:     1,
+			scope:         scope,
+			logger:        logger,
+			tenantDefault: "unknown",
+			tickDuration:  ptrDuration(tickDuration),
+		})
+		require.NoError(t, err)
+		return promStorage
+	}
 
 	t.Run("wrap non 5xx errors as invalid params error", func(t *testing.T) {
 		svr.Reset()
 		svr.SetError("test err", http.StatusForbidden)
+
+		scope := tally.NewTestScope("5xx_test_scope", map[string]string{})
+		promStorage := getPromStorage(scope)
 		err := writeTestMetric(t, promStorage, attr)
-		require.Error(t, err)
-		assert.True(t, xerrors.IsInvalidParams(err))
+		require.NoError(t, err)
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
+		tallytest.AssertCounterValue(
+			t, 1, scope.Snapshot(), "5xx_test_scope.prom_remote_storage.write.total",
+			map[string]string{"endpoint_name": "testEndpoint", "code": "403"},
+		)
+		tallytest.AssertCounterValue(
+			t, 1, scope.Snapshot(), "5xx_test_scope.prom_remote_storage.batch_write_err",
+			map[string]string{},
+		)
 	})
 
-	t.Run("429 should not be wrapped as invalid params", func(t *testing.T) {
+	t.Run("409 is not an error", func(t *testing.T) {
 		svr.Reset()
-		svr.SetError("test err", http.StatusTooManyRequests)
+		svr.SetError("test err", http.StatusConflict)
+
+		scope := tally.NewTestScope("409_test_scope", map[string]string{})
+		promStorage := getPromStorage(scope)
 		err := writeTestMetric(t, promStorage, attr)
-		require.Error(t, err)
-		assert.False(t, xerrors.IsInvalidParams(err))
+		require.NoError(t, err)
+
+		// Close() ensures writes get flushed
+		require.NoError(t, promStorage.Close())
+
+		tallytest.AssertCounterValue(
+			t, 1, scope.Snapshot(), "409_test_scope.prom_remote_storage.write.total",
+			map[string]string{"endpoint_name": "testEndpoint", "code": "409"},
+		)
+		tallytest.AssertCounterValue(
+			t, 0, scope.Snapshot(), "409_test_scope.prom_remote_storage.batch_write_err",
+			map[string]string{},
+		)
 	})
 }
-*/
 
 func closeWithCheck(t *testing.T, c io.Closer) {
 	require.NoError(t, c.Close())


### PR DESCRIPTION
## Problems that are fixed

1. A context is propagated all the way down to the http requests to Pantheon router. When the context is done and the big for loop exits, all pending http requests and new requests upon the last flushing will be cancelled because their context is already done. This may explain why we saw tiny data discrepancy between m3 and pantheon.
2. Use a for loop var in a Go function.
![image](https://github.com/databricks/m3/assets/129140017/d2b3a647-78e2-432e-baba-d10279468188)
3. Pantheon has two write endpoints configured. One is for raw data samples. The other is for aggregated ones. A data sample is supposed to be routed to one endpoint. That’s achieved by comparing resolution and retention. In contrast, M3 storage Write() uses a property from the write request. I suspect a tenant can match two resolution/retention settings in the for loop. 

```
$ go test github.com/m3db/m3/src/query/storage/promremote -v

$ go test github.com/m3db/m3/src/query/storage/promremote -v -race

```