### PR TITLE
[PLAT-108183] flush whenever the batch size is small and sort in timestamp to meet remote write spec

### DIFF
--- a/src/query/storage/promremote/query_coverter.go
+++ b/src/query/storage/promremote/query_coverter.go
@@ -21,6 +21,7 @@
 package promremote
 
 import (
+	"sort"
 	"time"
 
 	"github.com/m3db/m3/src/query/storage"
@@ -70,6 +71,11 @@ func convertWriteQuery(queries []*storage.WriteQuery) (*prompb.WriteRequest, int
 				Timestamp: dp.Timestamp.ToNormalizedTime(time.Millisecond),
 			})
 		}
+		// Need to make sure the samples meet remote write spec:
+		// https://prometheus.io/docs/concepts/remote_write_spec/#ordering
+		sort.Slice(samples, func(i, j int) bool {
+			return samples[i].Timestamp < samples[j].Timestamp
+		})
 		ts = append(ts, prompb.TimeSeries{
 			Labels:  labels,
 			Samples: samples,

--- a/src/query/storage/promremote/storage_test.go
+++ b/src/query/storage/promremote/storage_test.go
@@ -44,14 +44,13 @@ import (
 )
 
 var (
-	logger, _ = zap.NewDevelopment()
-	scope     = tally.NewTestScope("test_scope", map[string]string{})
-
+	logger, _    = zap.NewDevelopment()
 	tickDuration = time.Duration(100) * time.Millisecond
 )
 
 func TestWrite(t *testing.T) {
 	fakeProm := promremotetest.NewServer(t)
+	scope := tally.NewTestScope("test_scope", map[string]string{})
 	defer fakeProm.Close()
 	promStorage, err := NewStorage(Options{
 		endpoints:     []EndpointOptions{{name: "testEndpoint", address: fakeProm.WriteAddr(), tenantHeader: "TENANT"}},
@@ -173,14 +172,10 @@ func TestDataRace(t *testing.T) {
 	wq.Reset(storage.WriteQueryOptions{
 		Tags: models.Tags{
 			Opts: models.NewTagOptions(),
-			Tags: []models.Tag{{
-				Name:  []byte("new_tag_name"),
-				Value: []byte("new_tag_value"),
+			Tags: []models.Tag{
+				{Name: []byte("new_tag_name"), Value: []byte("new_tag_value")},
+				{Name: []byte("new_tag_name2"), Value: []byte("new_tag_value2")},
 			},
-				{
-					Name:  []byte("new_tag_name2"),
-					Value: []byte("new_tag_value2"),
-				}},
 		},
 		Datapoints: ts.Datapoints{{
 			Timestamp: now,
@@ -217,6 +212,7 @@ func TestDataRace(t *testing.T) {
 }
 
 func TestWriteBasedOnRetention(t *testing.T) {
+	scope := tally.NewTestScope("test_scope", map[string]string{})
 	promShortRetention := promremotetest.NewServer(t)
 	defer promShortRetention.Close()
 	promMediumRetention := promremotetest.NewServer(t)


### PR DESCRIPTION
Unit Test pass:

```
GOROOT=/opt/homebrew/opt/go/libexec #gosetup
GOPATH=/Users/yi.jin/go #gosetup
/opt/homebrew/opt/go/libexec/bin/go test -c -o /Users/yi.jin/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___go_test_github_com_m3db_m3_src_query_storage_promremote.test github.com/m3db/m3/src/query/storage/promremote #gosetup
/opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/yi.jin/Library/Caches/JetBrains/IntelliJIdea2023.2/tmp/GoLand/___go_test_github_com_m3db_m3_src_query_storage_promremote.test -test.v -test.paniconexit0
=== RUN   TestNewFromConfiguration
--- PASS: TestNewFromConfiguration (0.00s)
=== RUN   TestTenantRules
--- PASS: TestTenantRules (0.00s)
=== RUN   TestUnaggregatedEndpoint
--- PASS: TestUnaggregatedEndpoint (0.00s)
=== RUN   TestDefaultDownsampleAll
--- PASS: TestDefaultDownsampleAll (0.00s)
=== RUN   TestHTTPDefaults
--- PASS: TestHTTPDefaults (0.00s)
=== RUN   TestValidation
--- PASS: TestValidation (0.00s)
=== RUN   TestValidation/can't_be_nil
    --- PASS: TestValidation/can't_be_nil (0.00s)
=== RUN   TestValidation/at_least_1_endpoint
    --- PASS: TestValidation/at_least_1_endpoint (0.00s)
=== RUN   TestValidation/valid_endpoint
    --- PASS: TestValidation/valid_endpoint (0.00s)
=== RUN   TestValidation/name_required_for_endpoint
    --- PASS: TestValidation/name_required_for_endpoint (0.00s)
=== RUN   TestValidation/name_must_be_unique
    --- PASS: TestValidation/name_must_be_unique (0.00s)
=== RUN   TestValidation/non_negative_keep_alive
    --- PASS: TestValidation/non_negative_keep_alive (0.00s)
=== RUN   TestValidation/non_negative_max_idle_conns
    --- PASS: TestValidation/non_negative_max_idle_conns (0.00s)
=== RUN   TestValidation/non_negative_idle_conn_timeout
    --- PASS: TestValidation/non_negative_idle_conn_timeout (0.00s)
=== RUN   TestValidation/non_negative_request_timeout
    --- PASS: TestValidation/non_negative_request_timeout (0.00s)
=== RUN   TestValidation/non_negative_connect_timeout
    --- PASS: TestValidation/non_negative_connect_timeout (0.00s)
=== RUN   TestValidateEndpoint
--- PASS: TestValidateEndpoint (0.00s)
=== RUN   TestValidateEndpoint/address_required
    --- PASS: TestValidateEndpoint/address_required (0.00s)
=== RUN   TestValidateEndpoint/address_spaces_trimmed
    --- PASS: TestValidateEndpoint/address_spaces_trimmed (0.00s)
=== RUN   TestValidateEndpoint/storage_policy_is_optional
    --- PASS: TestValidateEndpoint/storage_policy_is_optional (0.00s)
=== RUN   TestValidateEndpoint/retention_must_be_positive
    --- PASS: TestValidateEndpoint/retention_must_be_positive (0.00s)
=== RUN   TestValidateEndpoint/resolution_must_be_positive
    --- PASS: TestValidateEndpoint/resolution_must_be_positive (0.00s)
=== RUN   TestValidateEndpoint/tenant_header_must_be_set
    --- PASS: TestValidateEndpoint/tenant_header_must_be_set (0.00s)
=== RUN   TestWriteQueryConverter
--- PASS: TestWriteQueryConverter (0.00s)
=== RUN   TestWriteQueryConverter/single_datapoint
    --- PASS: TestWriteQueryConverter/single_datapoint (0.00s)
=== RUN   TestWriteQueryConverter/duplicate_tags_and_samples
    --- PASS: TestWriteQueryConverter/duplicate_tags_and_samples (0.00s)
=== RUN   TestWriteQueryConverter/overrides_metric_name_tag
    --- PASS: TestWriteQueryConverter/overrides_metric_name_tag (0.00s)
=== RUN   TestWriteQueryConverter/overrides_bucket_name_name_tag
    --- PASS: TestWriteQueryConverter/overrides_bucket_name_name_tag (0.00s)
=== RUN   TestConvertQueryNil
--- PASS: TestConvertQueryNil (0.00s)
=== RUN   TestEncodeWriteQuery
--- PASS: TestEncodeWriteQuery (0.00s)
=== RUN   TestWrite
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 1, "poolSize": 1}
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:16.051-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
--- PASS: TestWrite (0.00s)
=== RUN   TestDataRace
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 100, "poolSize": 10}
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:16.052-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
--- PASS: TestDataRace (0.00s)
=== RUN   TestWriteBasedOnRetention
--- PASS: TestWriteBasedOnRetention (7.06s)
=== RUN   TestWriteBasedOnRetention/send_short_retention_write
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 9, "poolSize": 1}
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:16.053-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
    --- PASS: TestWriteBasedOnRetention/send_short_retention_write (2.01s)
=== RUN   TestWriteBasedOnRetention/send_medium_retention_write
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 9, "poolSize": 1}
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:18.060-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
    --- PASS: TestWriteBasedOnRetention/send_medium_retention_write (0.00s)
=== RUN   TestWriteBasedOnRetention/send_write_to_multiple_instances_configured_with_same_retention
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 9, "poolSize": 1}
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:18.062-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:18.066-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
    --- PASS: TestWriteBasedOnRetention/send_write_to_multiple_instances_configured_with_same_retention (3.03s)
=== RUN   TestWriteBasedOnRetention/send_unconfigured_retention_write
2024-05-08T14:06:21.096-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:21.096-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 9, "poolSize": 1}
2024-05-08T14:06:21.096-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:21.096-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:21.097-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:21.097-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:21.097-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 2}
2024-05-08T14:06:21.099-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 2}
    --- PASS: TestWriteBasedOnRetention/send_unconfigured_retention_write (2.02s)
=== RUN   TestWriteBasedOnRetention/error_should_not_prevent_sending_to_other_instances
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 9, "poolSize": 1}
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:23.113-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:23.115-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
    --- PASS: TestWriteBasedOnRetention/error_should_not_prevent_sending_to_other_instances (0.00s)
=== RUN   TestErrorHandling
--- PASS: TestErrorHandling (0.10s)
=== RUN   TestErrorHandling/wrap_non_5xx_errors_as_invalid_params_error
2024-05-08T14:06:23.116-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:23.116-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 1, "poolSize": 1}
2024-05-08T14:06:23.117-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:23.117-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:23.117-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:23.117-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:23.117-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:23.220-0700	ERROR	promremote/storage.go:113	error writing async batch	{"tenant": "unknown", "error": "expected status code 2XX: actual=403,  resp=test err\n"}
github.com/m3db/m3/src/query/storage/promremote.(*WriteQueue).Flush
	/Users/yi.jin/databricks/m3/src/query/storage/promremote/storage.go:113
github.com/m3db/m3/src/query/storage/promremote.(*promStorage).flushPendingQueues.func1
	/Users/yi.jin/databricks/m3/src/query/storage/promremote/storage.go:234
github.com/m3db/m3/src/x/sync.(*workerPool).GoInstrument.func1
	/Users/yi.jin/databricks/m3/src/x/sync/worker_pool.go:55
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
    --- PASS: TestErrorHandling/wrap_non_5xx_errors_as_invalid_params_error (0.10s)
=== RUN   TestErrorHandling/409_is_not_an_error
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:143	Creating a new promoremote storage...
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:298	Start prometheus remote write storage async job	{"queueSize": 1, "poolSize": 1}
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:182	Prometheus remote write storage created	{"num_tenants": 1}
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:302	Starting the write loop
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:253	Got the poison pill. Exiting the write loop.
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:286	Draining pending per-tenant write queues
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:288	Waiting for all async pending writes to finish	{"numWrites": 1}
2024-05-08T14:06:23.220-0700	INFO	promremote/storage.go:292	All async pending writes are done	{"numWrites": 1}
    --- PASS: TestErrorHandling/409_is_not_an_error (0.00s)
=== RUN   TestNamespaces
--- PASS: TestNamespaces (0.00s)
=== RUN   TestNamespaces/raw
    --- PASS: TestNamespaces/raw (0.00s)
=== RUN   TestNamespaces/donwsampled
    --- PASS: TestNamespaces/donwsampled (0.00s)
=== RUN   TestNamespaces/donwsampled_all_false
    --- PASS: TestNamespaces/donwsampled_all_false (0.00s)
=== RUN   TestNewSessionPanics
--- PASS: TestNewSessionPanics (0.00s)
PASS

Process finished with the exit code 0
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
