### PR TITLE
Optimize pre-aggregation rule matching CPU usage

### DIFF
--- a/src/metrics/filters/filter.go
+++ b/src/metrics/filters/filter.go
@@ -87,6 +87,9 @@ type TagsFilter interface {
 	fmt.Stringer
 	// Matches returns true if the conditions are met.
 	Matches(val []byte, opts TagMatchOptions) (bool, error)
+	MatchesWithNameAndTags(name, tags []byte, opts TagMatchOptions) (bool, error)
+
+	NameFilterValue() *FilterValue
 
 	// The original TagsFilter only works with encoded tags and need to decode tags using a decoder.
 	MatchTags(tags models.Tags) bool

--- a/src/metrics/filters/filter_benchmark_test.go
+++ b/src/metrics/filters/filter_benchmark_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/metrics/metric/id"
+	"github.com/m3db/m3/src/query/models"
 
 	"github.com/stretchr/testify/require"
 )
@@ -266,6 +267,18 @@ func newTestMapTagsFilter(
 
 func (f *testMapTagsFilter) String() string {
 	return ""
+}
+
+func (f *testMapTagsFilter) MatchesWithNameAndTags(_, _ []byte, _ TagMatchOptions) (bool, error) {
+	panic("not implemented")
+}
+
+func (f *testMapTagsFilter) NameFilterValue() *FilterValue {
+	panic("not implemented")
+}
+
+func (f *testMapTagsFilter) MatchTags(_ models.Tags) bool {
+	panic("not implemented")
 }
 
 func (f *testMapTagsFilter) Matches(id []byte, _ TagMatchOptions) (bool, error) {

--- a/src/metrics/filters/tags_filter_test.go
+++ b/src/metrics/filters/tags_filter_test.go
@@ -94,6 +94,7 @@ func TestNonexistTagsFilterMatches(t *testing.T) {
 		"tagName2": FilterValue{Pattern: "*"},
 	}
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
+	require.Equal(t, (*FilterValue)(nil), f.NameFilterValue())
 	inputs := []mockFilterData{
 		{val: "tagName1=tagValue1,tagName2=abc", match: true},
 		{val: "tagName1=tagValue1", match: false},
@@ -114,6 +115,7 @@ func TestTagsFilterMatchesNoNameTag(t *testing.T) {
 		"tagName2": FilterValue{Pattern: "tagValue2"},
 	}
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
+	require.Equal(t, (*FilterValue)(nil), f.NameFilterValue())
 	inputs := []mockFilterData{
 		{val: "tagName1=tagValue1,tagName2=tagValue2", match: true},
 		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3", match: true},
@@ -129,6 +131,7 @@ func TestTagsFilterMatchesNoNameTag(t *testing.T) {
 	}
 
 	f, err = NewTagsFilter(filters, Disjunction, testTagsFilterOptions())
+	require.Equal(t, (*FilterValue)(nil), f.NameFilterValue())
 	inputs = []mockFilterData{
 		{val: "tagName1=tagValue1,tagName2=tagValue2", match: true},
 		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3", match: true},
@@ -156,6 +159,9 @@ func TestTagsFilterMatchesWithNameTag(t *testing.T) {
 	}
 
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
+	require.NotEqual(t, (*FilterValue)(nil), f.NameFilterValue())
+	require.Equal(t, "foo", f.NameFilterValue().Pattern)
+	require.Equal(t, false, f.NameFilterValue().Negate)
 	require.NoError(t, err)
 	inputs := []mockFilterData{
 		{val: "foo+tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2", match: true},

--- a/src/metrics/matcher/options.go
+++ b/src/metrics/matcher/options.go
@@ -142,6 +142,9 @@ type Options interface {
 
 	// SetInterruptedCh sets the interrupted channel.
 	SetInterruptedCh(value <-chan struct{}) Options
+
+	SetUseFastMatch() Options
+	UseFastMatch() bool
 }
 
 type options struct {
@@ -159,6 +162,7 @@ type options struct {
 	onRuleSetUpdatedFn          OnRuleSetUpdatedFn
 	requireNamespaceWatchOnInit bool
 	interruptedCh               <-chan struct{}
+	useFastMatch                bool
 }
 
 // NewOptions creates a new set of options.
@@ -175,6 +179,17 @@ func NewOptions() Options {
 		matchRangePast:   defaultMatchRangePast,
 	}
 }
+
+func (o *options) SetUseFastMatch() Options {
+	opts := *o
+	opts.useFastMatch = true
+	return &opts
+}
+
+func (o *options) UseFastMatch() bool {
+	return o.useFastMatch
+}
+
 
 func (o *options) SetClockOptions(value clock.Options) Options {
 	opts := *o

--- a/src/metrics/matcher/ruleset_test.go
+++ b/src/metrics/matcher/ruleset_test.go
@@ -297,6 +297,7 @@ func (r *mockRuleSet) ToMutableRuleSet() rules.MutableRuleSet   { return nil }
 func (r *mockRuleSet) MappingRules() (view.MappingRules, error) { return nil, nil }
 func (r *mockRuleSet) RollupRules() (view.RollupRules, error)   { return nil, nil }
 func (r *mockRuleSet) Latest() (view.RuleSet, error)            { return view.RuleSet{}, nil }
+func (r *mockRuleSet) UseFastMatch()                            {}
 
 func testRuleSet() (kv.Store, cache.Cache, *ruleSet) {
 	store := mem.NewStore()

--- a/src/metrics/rules/options.go
+++ b/src/metrics/rules/options.go
@@ -44,17 +44,31 @@ type Options interface {
 
 	// IsRollupIDFn returns the function that determines whether an id is a rollup id.
 	IsRollupIDFn() id.MatchIDFn
+
+	SetUseFastMatch() Options
+	UseFastMatch() bool
 }
 
 type options struct {
 	tagsFilterOpts filters.TagsFilterOptions
 	newRollupIDFn  id.NewIDFn
 	isRollupIDFn   id.MatchIDFn
+	useFastMatch   bool
 }
 
 // NewOptions creates a new set of options.
 func NewOptions() Options {
 	return &options{}
+}
+
+func (o *options) SetUseFastMatch() Options {
+	opts := *o
+	opts.useFastMatch = true
+	return &opts
+}
+
+func (o *options) UseFastMatch() bool {
+	return o.useFastMatch
 }
 
 func (o *options) SetTagsFilterOptions(value filters.TagsFilterOptions) Options {

--- a/src/metrics/rules/store/kv/options.go
+++ b/src/metrics/rules/store/kv/options.go
@@ -29,6 +29,7 @@ type StoreOptions struct {
 	NamespacesKey string
 	RuleSetKeyFmt string
 	Validator     rules.Validator
+	UseFastMatch  bool
 }
 
 // NewStoreOptions creates a new store options struct.

--- a/src/metrics/rules/store/kv/store.go
+++ b/src/metrics/rules/store/kv/store.go
@@ -23,6 +23,7 @@ package kv
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/m3db/m3/src/cluster/kv"
 	merrors "github.com/m3db/m3/src/metrics/errors"
@@ -80,6 +81,10 @@ func (s *store) ReadRuleSet(nsName string) (rules.RuleSet, error) {
 	rs, err := rules.NewRuleSetFromProto(version, &ruleSet, rules.NewOptions())
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch RuleSet %s: %v", nsName, err.Error())
+	}
+	if s.opts.UseFastMatch {
+		rs.UseFastMatch()
+		log.Default().Printf("using fast match for RuleSet %s", nsName)
 	}
 	return rs, err
 }


### PR DESCRIPTION
## Unit tests
```
$ go test  github.com/m3db/m3/src/metrics/filter
$ go test github.com/m3db/m3/src/metrics/rule
$ make m3coordinator
mkdir -p /Users/hc.zhu/m3/bin
Building m3coordinator


$ go test github.com/m3db/m3/src/metrics/rules

Ceated mappingRuleIndex of 2 entries for 11 mapping rules and rollupRuleIndex of 0 entries for 0 rollup rules
      mappingRuleIndex[metric1] has 8 rules
      mappingRuleIndex[metric2] has 3 rules
 Ceated mappingRuleIndex of 0 entries for 0 mapping rules and rollupRuleIndex of 2 entries for 11 rollup rules
      rollupRuleIndex[metric1] has 7 rules
      rollupRuleIndex[metric2] has 4 rules
```
## deploying to a dev shard

https://github.com/databricks/universe/pull/697199