### PR TITLE
Add support for exclude tag rules in aggregation rules

### DIFF
--- a/src/metrics/filters/filter_benchmark_test.go
+++ b/src/metrics/filters/filter_benchmark_test.go
@@ -36,15 +36,15 @@ var (
 		"tagname4=tagvalue4,tagname2=tagvalue2,tagname6=tagvalue6," +
 		"tagname5=tagvalue5,name=my.test.metric.name,tagname7=tagvalue7")
 
-	testTagsFilterMapOne = map[string]FilterValue{
-		"tagname1": FilterValue{Pattern: "tagvalue1"},
+	testTagsFilterMapOne = map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"tagname1", false}: FilterValue{Pattern: "tagvalue1"},
 	}
 
-	testTagsFilterMapThree = map[string]FilterValue{
-		"tagname1":    FilterValue{Pattern: "tagvalue1"},
-		"tagname2":    FilterValue{Pattern: "tagvalue2"},
-		"tagname3":    FilterValue{Pattern: "tagvalue3"},
-		"faketagname": FilterValue{Pattern: "faketagvalue"},
+	testTagsFilterMapThree = map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"tagname1", false}:    FilterValue{Pattern: "tagvalue1"},
+		TagFilterValueMapKey{"tagname2", false}:    FilterValue{Pattern: "tagvalue2"},
+		TagFilterValueMapKey{"tagname3", false}:    FilterValue{Pattern: "tagvalue3"},
+		TagFilterValueMapKey{"faketagname", false}: FilterValue{Pattern: "faketagvalue"},
 	}
 )
 
@@ -254,9 +254,9 @@ func newTestMapTagsFilter(
 	iterFn id.SortedTagIteratorFn,
 ) TagsFilter {
 	filters := make(map[string]Filter, len(tagFilters))
-	for name, value := range tagFilters {
+	for entry, value := range tagFilters {
 		filter, _ := NewFilterFromFilterValue(value)
-		filters[name] = filter
+		filters[entry.Name] = filter
 	}
 
 	return &testMapTagsFilter{

--- a/src/metrics/filters/tags_filter.go
+++ b/src/metrics/filters/tags_filter.go
@@ -61,14 +61,23 @@ type tagFilterSeparator struct {
 	negate bool
 }
 
+type TagFilterValueMapKey struct {
+	Name    string
+	Exclude bool
+}
+
+func NewTagFilterValueMapKey(name string, exclude bool) TagFilterValueMapKey {
+	return TagFilterValueMapKey{Name: name, Exclude: exclude}
+}
+
 // TagFilterValueMap is a map containing mappings from tag names to filter values.
-type TagFilterValueMap map[string]FilterValue
+type TagFilterValueMap map[TagFilterValueMapKey]FilterValue
 
 // ParseTagFilterValueMap parses the input string and creates a tag filter value map.
 func ParseTagFilterValueMap(str string) (TagFilterValueMap, error) {
 	trimmed := strings.TrimSpace(str)
 	tagPairs := strings.Split(trimmed, tagFilterListSeparator)
-	res := make(map[string]FilterValue, len(tagPairs))
+	res := make(map[TagFilterValueMapKey]FilterValue, len(tagPairs))
 	for _, p := range tagPairs {
 		sanitized := strings.TrimSpace(p)
 		if sanitized == "" {
@@ -79,11 +88,24 @@ func ParseTagFilterValueMap(str string) (TagFilterValueMap, error) {
 			return nil, err
 		}
 		// NB: we do not allow duplicate tags at the moment.
-		_, exists := res[parts[0]]
+		exclude := parts[0][0] == negationChar
+		name := parts[0]
+		if exclude {
+			name = parts[0][1:]
+		}
+		key := TagFilterValueMapKey{Name: name, Exclude: exclude}
+		_, exists := res[key]
 		if exists {
 			return nil, fmt.Errorf("invalid filter %s: duplicate tag %s found", str, parts[0])
 		}
-		res[parts[0]] = FilterValue{Pattern: parts[1], Negate: separator.negate}
+		if key.Exclude {
+			// For exclude rules, it doesn't make sense to have a value filter pattern since we are simply checking for the absence of the tag.
+			// To avoid confusion, we enforce that the value filter pattern is a wildcard.
+			if parts[1] != string(wildcardChar) {
+				return nil, fmt.Errorf("invalid filter %s: negation only supported for wildcard patterns", str)
+			}
+		}
+		res[key] = FilterValue{Pattern: parts[1], Negate: separator.negate}
 	}
 	return res, nil
 }
@@ -119,10 +141,16 @@ func parseTagFilter(str string) ([]string, tagFilterSeparator, error) {
 type tagFilter struct {
 	name        []byte
 	valueFilter Filter
+	// exclude indicates whether we want to check for the absence of the tag.
+	exclude bool
 }
 
 func (f *tagFilter) String() string {
-	return fmt.Sprintf("%s:%s", string(f.name), f.valueFilter.String())
+	excludePrefix := ""
+	if f.exclude {
+		excludePrefix = string(negationChar)
+	}
+	return fmt.Sprintf("%s%s:%s", excludePrefix, string(f.name), f.valueFilter.String())
 }
 
 type tagFiltersByNameAsc []tagFilter
@@ -164,12 +192,16 @@ func NewTagsFilter(
 		tagFilters      = make([]tagFilter, 0, len(filters))
 		nameFilterValue FilterValue
 	)
-	for name, value := range filters {
+	for entry, value := range filters {
+		// We disallow OR support for exclude rules for simplicity.
+		if entry.Exclude && op == Disjunction {
+			return nil, fmt.Errorf("Invalid filter %s: exclude not supported for disjunction", entry.Name)
+		}
 		valFilter, err := NewFilterFromFilterValue(value)
 		if err != nil {
 			return nil, err
 		}
-		bName := []byte(name)
+		bName := []byte(entry.Name)
 		if bytes.Equal(opts.NameTagKey, bName) {
 			nameFilter = valFilter
 			nameFilterValue = value
@@ -177,6 +209,7 @@ func NewTagsFilter(
 			tagFilters = append(tagFilters, tagFilter{
 				name:        bName,
 				valueFilter: valFilter,
+				exclude:     entry.Exclude,
 			})
 		}
 	}
@@ -210,7 +243,7 @@ func (f *tagsFilter) String() string {
 }
 
 func (f *tagsFilter) NameFilterValue() *FilterValue {
-	if f.nameFilter == nil { 
+	if f.nameFilter == nil {
 		return nil
 	}
 	return &f.nameFilterValue
@@ -248,6 +281,10 @@ func (f *tagsFilter) MatchesWithNameAndTags(name, tags []byte, opts TagMatchOpti
 
 		// Check if the current metric tag matches the current tag filter
 		comparison := bytes.Compare(name, f.tagFilters[currIdx].name)
+		if comparison == 0 && f.tagFilters[currIdx].exclude {
+			// We have a tagFilter that is looking for the absence of a tag.
+			return false, nil
+		}
 
 		// If the tags don't match, we move onto the next metric tag.
 		// This is correct because not every one of the metric tag's need be represented in the rule.
@@ -255,7 +292,30 @@ func (f *tagsFilter) MatchesWithNameAndTags(name, tags []byte, opts TagMatchOpti
 			continue
 		}
 
-		if comparison > 0 {
+		if comparison > 0 && f.tagFilters[currIdx].exclude {
+			// We have a tagFilter that is looking for the absence of a tag.
+			// Iterate through the remaining exclude tagFilters if any
+			currIdx++
+			for currIdx < len(f.tagFilters) && bytes.Compare(name, f.tagFilters[currIdx].name) > 0 && f.tagFilters[currIdx].exclude {
+				currIdx++
+			}
+
+			if currIdx == len(f.tagFilters) {
+				// We have reached the end after considering all exclude tag filters. Everything is good
+				continue
+			}
+			// We have reached the first tagFilter that is not an exclude tag filter.
+			newComparison := bytes.Compare(name, f.tagFilters[currIdx].name)
+			if newComparison < 0 {
+				// Not a problem
+				continue
+			} else if newComparison == 0 {
+				// Time to do a value match. Pass through
+			} else {
+				// We have a tagFilter that is looking for the presence of a tag and it's missing
+				return false, nil
+			}
+		} else if comparison > 0 {
 			if f.op == Conjunction {
 				// For AND, if the current filter tag doesn't exist, bail immediately.
 				return false, nil
@@ -291,11 +351,19 @@ func (f *tagsFilter) MatchesWithNameAndTags(name, tags []byte, opts TagMatchOpti
 	}
 
 	if iter.Err() != nil {
-		return false, iter.Err()
+		for currIdx < len(f.tagFilters) && f.tagFilters[currIdx].exclude {
+			currIdx++
+		}
+		if currIdx != len(f.tagFilters) {
+			return false, iter.Err()
+		}
 	}
 
 	if f.op == Disjunction {
 		return false, nil
+	}
+	for currIdx < len(f.tagFilters) && f.tagFilters[currIdx].exclude {
+		currIdx++
 	}
 
 	return currIdx == len(f.tagFilters), nil
@@ -310,12 +378,16 @@ func (f *tagsFilter) MatchTags(tags models.Tags) bool {
 	for i := 0; i < len(tags.Tags) && curr < len(f.tagFilters); i++ {
 		tag := tags.Tags[i]
 		comparison := bytes.Compare(tag.Name, f.tagFilters[curr].name)
+		if comparison == 0 && f.tagFilters[curr].exclude {
+			// We have a tagFilter that is looking for the absence of a tag.
+			return false
+		}
 		if comparison < 0 {
 			// If the tags don't match, we move onto the next metric tag.
 			// This is correct because not every one of the metric tag's need be represented in the rule.
 			continue
 		}
-		if comparison > 0 {
+		if comparison > 0 && !f.tagFilters[curr].exclude {
 			if f.op == Conjunction {
 				// For AND, if the current filter tag doesn't exist, bail immediately.
 				return false
@@ -324,6 +396,10 @@ func (f *tagsFilter) MatchTags(tags models.Tags) bool {
 			curr++
 			i--
 			continue
+		}
+		if comparison == 0 && f.tagFilters[curr].exclude {
+			// We have a tagFilter that is looking for the absence of a tag.
+			return false
 		}
 		match := f.tagFilters[curr].valueFilter.Matches(tag.Value)
 		if match && f.op == Disjunction {
@@ -335,6 +411,10 @@ func (f *tagsFilter) MatchTags(tags models.Tags) bool {
 		}
 		curr++
 	}
+	for curr < len(f.tagFilters) && f.tagFilters[curr].exclude {
+		curr++
+	}
+
 	return curr == len(f.tagFilters)
 }
 
@@ -346,10 +426,10 @@ func ValidateTagsFilter(str string) (TagFilterValueMap, error) {
 	if err != nil {
 		return nil, errors.NewValidationError(fmt.Sprintf("tags filter %s is malformed: %v", str, err))
 	}
-	for name, value := range filterValues {
+	for entry, value := range filterValues {
 		// Validating the filter value by actually constructing the filter.
 		if _, err := NewFilterFromFilterValue(value); err != nil {
-			return nil, errors.NewValidationError(fmt.Sprintf("tags filter %s contains invalid filter pattern %s for tag %s: %v", str, value.Pattern, name, err))
+			return nil, errors.NewValidationError(fmt.Sprintf("tags filter %s contains invalid filter pattern %s for tag %s: %v", str, value.Pattern, entry.Name, err))
 		}
 	}
 	return filterValues, nil

--- a/src/metrics/filters/tags_filter_test.go
+++ b/src/metrics/filters/tags_filter_test.go
@@ -37,23 +37,33 @@ func TestParseTagFilterValueMap(t *testing.T) {
 		{
 			str: "tagName1:tagValue1",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
 			},
 		},
 		{
 			str: "tagName1:tagValue1 tagName2:tagValue2",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1", Negate: false},
-				"tagName2": FilterValue{Pattern: "tagValue2", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2", Negate: false},
 			},
 		},
 		{
 			str: "  tagName1:tagValue1    tagName2:tagValue2   tagName3:tagValue3  tagName4:tagValue4",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1", Negate: false},
-				"tagName2": FilterValue{Pattern: "tagValue2", Negate: false},
-				"tagName3": FilterValue{Pattern: "tagValue3", Negate: false},
-				"tagName4": FilterValue{Pattern: "tagValue4", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2", Negate: false},
+				TagFilterValueMapKey{"tagName3", false}: FilterValue{Pattern: "tagValue3", Negate: false},
+				TagFilterValueMapKey{"tagName4", false}: FilterValue{Pattern: "tagValue4", Negate: false},
+			},
+		},
+		{
+			str: "  tagName1:tagValue1    tagName2:tagValue2   tagName3:tagValue3  tagName4:tagValue4  !tagName5:*",
+			expected: TagFilterValueMap{
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2", Negate: false},
+				TagFilterValueMapKey{"tagName3", false}: FilterValue{Pattern: "tagValue3", Negate: false},
+				TagFilterValueMapKey{"tagName4", false}: FilterValue{Pattern: "tagValue4", Negate: false},
+				TagFilterValueMapKey{"tagName5", true}:  FilterValue{Pattern: "*", Negate: false},
 			},
 		},
 	}
@@ -72,6 +82,7 @@ func TestParseTagFilterValueMapErrors(t *testing.T) {
 		"tagName1:tagValue1  tagName2:tagValue2 tagName1:tagValue3",
 		"tagName:",
 		":tagValue",
+		"!tagValue5:xyz",
 	}
 
 	for _, input := range inputs {
@@ -89,9 +100,9 @@ func TestEmptyTagsFilterMatches(t *testing.T) {
 }
 
 func TestNonexistTagsFilterMatches(t *testing.T) {
-	filters := map[string]FilterValue{
-		"tagName1": FilterValue{Pattern: "tagValue1"},
-		"tagName2": FilterValue{Pattern: "*"},
+	filters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "*"},
 	}
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
 	require.Equal(t, (*FilterValue)(nil), f.NameFilterValue())
@@ -110,18 +121,23 @@ func TestNonexistTagsFilterMatches(t *testing.T) {
 }
 
 func TestTagsFilterMatchesNoNameTag(t *testing.T) {
-	filters := map[string]FilterValue{
-		"tagName1": FilterValue{Pattern: "tagValue1"},
-		"tagName2": FilterValue{Pattern: "tagValue2"},
+	filters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
+		TagFilterValueMapKey{"tagName4", true}:  FilterValue{Pattern: "*"},
+		TagFilterValueMapKey{"tagName5", false}: FilterValue{Pattern: "tagValue5"},
 	}
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
 	require.Equal(t, (*FilterValue)(nil), f.NameFilterValue())
 	inputs := []mockFilterData{
-		{val: "tagName1=tagValue1,tagName2=tagValue2", match: true},
-		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3", match: true},
+		{val: "tagName1=tagValue1,tagName2=tagValue2,tagName5=tagValue5", match: true},
+		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3,tagName5=tagValue5", match: true},
 		{val: "tagName1=tagValue1", match: false},
 		{val: "tagName2=tagValue2", match: false},
 		{val: "tagName1=tagValue2,tagName2=tagValue1", match: false},
+		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3,tagName4=tagValue4", match: false},
+		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName4=tagValue4,tagName5=tagValue5", match: false},
+		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName5=tagValue5,tagName6=tagValue6", match: true},
 	}
 	require.NoError(t, err)
 	for _, input := range inputs {
@@ -130,7 +146,12 @@ func TestTagsFilterMatchesNoNameTag(t *testing.T) {
 		require.Equal(t, input.match, matches)
 	}
 
-	f, err = NewTagsFilter(filters, Disjunction, testTagsFilterOptions())
+	disjunctionFilters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
+		TagFilterValueMapKey{"tagName5", false}: FilterValue{Pattern: "tagValue5"},
+	}
+	f, err = NewTagsFilter(disjunctionFilters, Disjunction, testTagsFilterOptions())
 	require.Equal(t, (*FilterValue)(nil), f.NameFilterValue())
 	inputs = []mockFilterData{
 		{val: "tagName1=tagValue1,tagName2=tagValue2", match: true},
@@ -152,10 +173,11 @@ func TestTagsFilterMatchesNoNameTag(t *testing.T) {
 }
 
 func TestTagsFilterMatchesWithNameTag(t *testing.T) {
-	filters := map[string]FilterValue{
-		"name":     FilterValue{Pattern: "foo"},
-		"tagName1": FilterValue{Pattern: "tagValue1"},
-		"tagName2": FilterValue{Pattern: "tagValue2"},
+	filters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"name", false}:     FilterValue{Pattern: "foo"},
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
+		TagFilterValueMapKey{"tagName4", true}:  FilterValue{Pattern: "*"},
 	}
 
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
@@ -168,6 +190,7 @@ func TestTagsFilterMatchesWithNameTag(t *testing.T) {
 		{val: "tagName1=tagValue1,tagName2=tagValue2", match: false, err: errInvalidMetric},
 		{val: "foo+tagName1=tagValue1", match: false},
 		{val: "foo+tagName1=tagValue2,tagName2=tagValue1", match: false},
+		{val: "foo+tagName1=tagValue2,tagName2=tagValue1,tagName4=tagValue4", match: false},
 	}
 	for _, input := range inputs {
 		matches, err := f.Matches([]byte(input.val), testTagsMatchOptionsWithNameTag())
@@ -179,7 +202,16 @@ func TestTagsFilterMatchesWithNameTag(t *testing.T) {
 		require.Equal(t, input.match, matches)
 	}
 
+	// We should hit an error if we try to have an exclude rule with disjunction
 	f, err = NewTagsFilter(filters, Disjunction, testTagsFilterOptions())
+	require.Error(t, err)
+
+	disjunctionFilters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"name", false}:     FilterValue{Pattern: "foo"},
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
+	}
+	f, err = NewTagsFilter(disjunctionFilters, Disjunction, testTagsFilterOptions())
 	require.NoError(t, err)
 	inputs = []mockFilterData{
 		{val: "foo+tagName1=tagValue1,tagName2=tagValue2", match: true},
@@ -204,9 +236,9 @@ func TestTagsFilterMatchesWithNameTag(t *testing.T) {
 }
 
 func TestTagsFilterStringNoNameTag(t *testing.T) {
-	filters := map[string]FilterValue{
-		"tagName1": FilterValue{Pattern: "tagValue1"},
-		"tagName2": FilterValue{Pattern: "tagValue2"},
+	filters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
 	}
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
 	require.NoError(t, err)
@@ -220,17 +252,27 @@ func TestTagsFilterStringNoNameTag(t *testing.T) {
 }
 
 func TestTagsFilterStringWithNameTag(t *testing.T) {
-	filters := map[string]FilterValue{
-		"name":     FilterValue{Pattern: "foo"},
-		"tagName1": FilterValue{Pattern: "tagValue1"},
-		"tagName2": FilterValue{Pattern: "tagValue2"},
+	filters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"name", false}:     FilterValue{Pattern: "foo"},
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
+		TagFilterValueMapKey{"tagName3", true}:  FilterValue{Pattern: "*"},
 	}
 	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
 	require.NoError(t, err)
 	tf := f.(*tagsFilter)
-	require.Equal(t, `name:Equals("foo") && tagName1:Equals("tagValue1") && tagName2:Equals("tagValue2")`, tf.String())
+	require.Equal(t, `name:Equals("foo") && tagName1:Equals("tagValue1") && tagName2:Equals("tagValue2") && !tagName3:All`, tf.String())
 
+	// We should hit an error if we try to have an exclude rule with disjunction
 	f, err = NewTagsFilter(filters, Disjunction, testTagsFilterOptions())
+	require.Error(t, err)
+
+	disjunctionFilters := map[TagFilterValueMapKey]FilterValue{
+		TagFilterValueMapKey{"name", false}:     FilterValue{Pattern: "foo"},
+		TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1"},
+		TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2"},
+	}
+	f, err = NewTagsFilter(disjunctionFilters, Disjunction, testTagsFilterOptions())
 	require.NoError(t, err)
 	tf = f.(*tagsFilter)
 	require.Equal(t, `name:Equals("foo") || tagName1:Equals("tagValue1") || tagName2:Equals("tagValue2")`, tf.String())
@@ -244,23 +286,23 @@ func TestValidateTagsFilter(t *testing.T) {
 		{
 			str: "tagName1:tagValue1",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
 			},
 		},
 		{
 			str: "tagName1:tagValue1 tagName2:tagValue2*tagValue3",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1", Negate: false},
-				"tagName2": FilterValue{Pattern: "tagValue2*tagValue3", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2*tagValue3", Negate: false},
 			},
 		},
 		{
 			str: "  tagName1:tagValue1?[0-9][!a-z]9    tagName2:{tagValue21,tagValue22}*   tagName3:tagValue3  tagName4:tagValue4",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1?[0-9][!a-z]9", Negate: false},
-				"tagName2": FilterValue{Pattern: "{tagValue21,tagValue22}*", Negate: false},
-				"tagName3": FilterValue{Pattern: "tagValue3", Negate: false},
-				"tagName4": FilterValue{Pattern: "tagValue4", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1?[0-9][!a-z]9", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "{tagValue21,tagValue22}*", Negate: false},
+				TagFilterValueMapKey{"tagName3", false}: FilterValue{Pattern: "tagValue3", Negate: false},
+				TagFilterValueMapKey{"tagName4", false}: FilterValue{Pattern: "tagValue4", Negate: false},
 			},
 		},
 	}
@@ -280,37 +322,37 @@ func TestValidateTagsFilterWithSpecialChar(t *testing.T) {
 		{
 			str: "tagName1#tagValue1",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1", Negate: false},
 			},
 		},
 		{
 			// NB: '#' has a high priority than ':'.
 			str: "tagName1#tagValue1:suffix",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1:suffix", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1:suffix", Negate: false},
 			},
 		},
 		{
 			// NB: '#' has a high priority than ':'.
 			str: "tagName1#tagValue1:suffix:",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1:suffix:", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1:suffix:", Negate: false},
 			},
 		},
 		{
 			str: "tagName1#tagValue1:suffix:a:b:: tagName2:tagValue2*tagValue3#a#",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1:suffix:a:b::", Negate: false},
-				"tagName2": FilterValue{Pattern: "tagValue2*tagValue3#a#", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1:suffix:a:b::", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "tagValue2*tagValue3#a#", Negate: false},
 			},
 		},
 		{
 			str: "  tagName1#tagValue1?[0-9][!a-z]9    tagName2#a:{tagValue21,tagValue22}*   tagName3:tagValue3  tagName4:tagValue4",
 			expected: TagFilterValueMap{
-				"tagName1": FilterValue{Pattern: "tagValue1?[0-9][!a-z]9", Negate: false},
-				"tagName2": FilterValue{Pattern: "a:{tagValue21,tagValue22}*", Negate: false},
-				"tagName3": FilterValue{Pattern: "tagValue3", Negate: false},
-				"tagName4": FilterValue{Pattern: "tagValue4", Negate: false},
+				TagFilterValueMapKey{"tagName1", false}: FilterValue{Pattern: "tagValue1?[0-9][!a-z]9", Negate: false},
+				TagFilterValueMapKey{"tagName2", false}: FilterValue{Pattern: "a:{tagValue21,tagValue22}*", Negate: false},
+				TagFilterValueMapKey{"tagName3", false}: FilterValue{Pattern: "tagValue3", Negate: false},
+				TagFilterValueMapKey{"tagName4", false}: FilterValue{Pattern: "tagValue4", Negate: false},
 			},
 		},
 	}
@@ -350,6 +392,10 @@ func TestValidateTagsFilterError(t *testing.T) {
 		{
 			str: "tagName1:aggr#tagValue1:suffix#",
 			err: "invalid filter tagName1:aggr#tagValue1:suffix#: expecting tag pattern pairs",
+		},
+		{
+			str: "!tagName1:aggr",
+			err: "invalid filter !tagName1:aggr: negation only supported for wildcard patterns",
 		},
 	}
 

--- a/src/metrics/rules/active_ruleset_test.go
+++ b/src/metrics/rules/active_ruleset_test.go
@@ -666,10 +666,10 @@ func TestActiveRuleSetForwardMatchWithMappingRulesFast(t *testing.T) {
 		},
 		{
 			// No matcing because the closest rule requires a different metric name, "metric1|mtagName1=mtagValue2".
-			id:            "metric2|mtagName1=mtagValue2",
-			matchFrom:     25000,
-			matchTo:       25001,
-			expireAtNanos: 30000,
+			id:                  "metric2|mtagName1=mtagValue2",
+			matchFrom:           25000,
+			matchTo:             25001,
+			expireAtNanos:       30000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
@@ -682,10 +682,10 @@ func TestActiveRuleSetForwardMatchWithMappingRulesFast(t *testing.T) {
 		},
 		{
 			// No matching because the closest rule requires a different metric name, "metric1|mtagName1=mtagValue1".
-			id:            "metric2|mtagName1=mtagValue1",
-			matchFrom:     10000,
-			matchTo:       40000,
-			expireAtNanos: 100000,
+			id:                  "metric2|mtagName1=mtagValue1",
+			matchFrom:           10000,
+			matchTo:             40000,
+			expireAtNanos:       100000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
@@ -894,33 +894,33 @@ func TestActiveRuleSetForwardMatchWithMappingRulesFast(t *testing.T) {
 		},
 		{
 			// No matching because the closest rule requires a different metric name, "metric2|mtagName1=mtagValue3",
-			id:            "metric1|mtagName1=mtagValue3",
-			matchFrom:     4000,
-			matchTo:       9000,
-			expireAtNanos: 10000,
+			id:                  "metric1|mtagName1=mtagValue3",
+			matchFrom:           4000,
+			matchTo:             9000,
+			expireAtNanos:       10000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
 			// No matching because the closest rule requires a different metric name, "metric1|mtagName1=mtagValue2",
-			id:            "metric2|mtagName1=mtagValue2",
-			matchFrom:     10000,
-			matchTo:       40000,
-			expireAtNanos: 100000,
+			id:                  "metric2|mtagName1=mtagValue2",
+			matchFrom:           10000,
+			matchTo:             40000,
+			expireAtNanos:       100000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
-			id:            "metric1|shouldDropTagName1=shouldDropTagValue1",
-			matchFrom:     25000,
-			matchTo:       25001,
-			expireAtNanos: 30000,
+			id:                  "metric1|shouldDropTagName1=shouldDropTagValue1",
+			matchFrom:           25000,
+			matchTo:             25001,
+			expireAtNanos:       30000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
 			// No matching because the closest rule requires a different metric name, "metric1|shouldDrop2TagName1=shouldDrop2TagValue1",
-			id:            "metric2|shouldDrop2TagName1=shouldDrop2TagValue1",
-			matchFrom:     25000,
-			matchTo:       25001,
-			expireAtNanos: 30000,
+			id:                  "metric2|shouldDrop2TagName1=shouldDrop2TagValue1",
+			matchFrom:           25000,
+			matchTo:             25001,
+			expireAtNanos:       30000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
@@ -948,10 +948,10 @@ func TestActiveRuleSetForwardMatchWithMappingRulesFast(t *testing.T) {
 		},
 		{
 			// No matching because the closest rule requires a different metric name, "metric1|shouldDrop2TagName1=shouldDrop2TagValue1",
-			id:            "metric3|shouldDrop2TagName1=shouldDrop2TagValue1",
-			matchFrom:     25000,
-			matchTo:       25001,
-			expireAtNanos: 30000,
+			id:                  "metric3|shouldDrop2TagName1=shouldDrop2TagValue1",
+			matchFrom:           25000,
+			matchTo:             25001,
+			expireAtNanos:       30000,
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 	}
@@ -1979,12 +1979,12 @@ func TestActiveRuleSetForwardMatchWithRollupRulesFast(t *testing.T) {
 			},
 		},
 		{
-			id:            "metric1|rtagName1=rtagValue2",
-			matchFrom:     25000,
-			matchTo:       25001,
-			expireAtNanos: 30000,
-			keepOriginal:  false,
-			forExistingIDResult: metadata.DefaultStagedMetadatas,
+			id:                    "metric1|rtagName1=rtagValue2",
+			matchFrom:             25000,
+			matchTo:               25001,
+			expireAtNanos:         30000,
+			keepOriginal:          false,
+			forExistingIDResult:   metadata.DefaultStagedMetadatas,
 			forNewRollupIDsResult: []IDWithMetadatas{},
 		},
 		{
@@ -2671,12 +2671,12 @@ func TestActiveRuleSetForwardMatchWithRollupRulesFast(t *testing.T) {
 			},
 		},
 		{
-			id:            "metric2|rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			matchFrom:     25000,
-			matchTo:       25001,
-			expireAtNanos: 30000,
-			keepOriginal:  false,
-			forExistingIDResult: metadata.DefaultStagedMetadatas,
+			id:                    "metric2|rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			matchFrom:             25000,
+			matchTo:               25001,
+			expireAtNanos:         30000,
+			keepOriginal:          false,
+			forExistingIDResult:   metadata.DefaultStagedMetadatas,
 			forNewRollupIDsResult: []IDWithMetadatas{},
 		},
 		{
@@ -2742,22 +2742,22 @@ func TestActiveRuleSetForwardMatchWithRollupRulesFast(t *testing.T) {
 			forExistingIDResult: metadata.DefaultStagedMetadatas,
 		},
 		{
-			id:            "metric2|rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			matchFrom:     10000,
-			matchTo:       40000,
-			expireAtNanos: 90000,
-			keepOriginal:  false,
-			forExistingIDResult: metadata.DefaultStagedMetadatas,
+			id:                    "metric2|rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			matchFrom:             10000,
+			matchTo:               40000,
+			expireAtNanos:         90000,
+			keepOriginal:          false,
+			forExistingIDResult:   metadata.DefaultStagedMetadatas,
 			forNewRollupIDsResult: []IDWithMetadatas{},
 		},
 		//nolint:dupl
 		{
-			id:            "metric2|rtagName1=rtagValue3,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			matchFrom:     100000,
-			matchTo:       110000,
-			expireAtNanos: 120000,
-			keepOriginal:  false,
-			forExistingIDResult: metadata.DefaultStagedMetadatas,
+			id:                    "metric2|rtagName1=rtagValue3,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			matchFrom:             100000,
+			matchTo:               110000,
+			expireAtNanos:         120000,
+			keepOriginal:          false,
+			forExistingIDResult:   metadata.DefaultStagedMetadatas,
 			forNewRollupIDsResult: []IDWithMetadatas{},
 		},
 	}
@@ -4739,8 +4739,8 @@ func TestMatchedKeepOriginal(t *testing.T) {
 
 	filter, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"foo": filters.FilterValue{Pattern: "bar"},
-			"baz": filters.FilterValue{Pattern: "bat"},
+			filters.TagFilterValueMapKey{"foo", false}: filters.FilterValue{Pattern: "bar"},
+			filters.TagFilterValueMapKey{"baz", false}: filters.FilterValue{Pattern: "bat"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -4834,43 +4834,43 @@ func TestMatchedKeepOriginal(t *testing.T) {
 
 func testMappingRules(t *testing.T) []*mappingRule {
 	filter1, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue1"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue1"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter2, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue2"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue2"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter3, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue3"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue3"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter4, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue4"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue4"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter5, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"shouldDropTagName1": filters.FilterValue{Pattern: "shouldDropTagValue1"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"shouldDropTagName1", false}: filters.FilterValue{Pattern: "shouldDropTagValue1"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter6, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"shouldDrop2TagName1": filters.FilterValue{Pattern: "shouldDrop2TagValue1"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"shouldDrop2TagName1", false}: filters.FilterValue{Pattern: "shouldDrop2TagValue1"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter7, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"shouldNotDropTagName1": filters.FilterValue{Pattern: "shouldNotDropTagValue1"}},
+		filters.TagFilterValueMap{filters.TagFilterValueMapKey{"shouldNotDropTagName1", false}: filters.FilterValue{Pattern: "shouldNotDropTagValue1"}},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
@@ -5147,43 +5147,64 @@ func testMappingRules(t *testing.T) []*mappingRule {
 
 func testMappingRulesWithNames(t *testing.T) []*mappingRule {
 	filter1, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue1"}, "name": filters.FilterValue{Pattern: "metric1"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue1"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric1"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter2, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue2"}, "name": filters.FilterValue{Pattern: "metric1"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue2"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric1"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter3, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue3"}, "name": filters.FilterValue{Pattern: "metric2"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue3"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric2"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter4, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"mtagName1": filters.FilterValue{Pattern: "mtagValue4"}, "name": filters.FilterValue{Pattern: "metric2"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"mtagName1", false}: filters.FilterValue{Pattern: "mtagValue4"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric2"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter5, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"shouldDropTagName1": filters.FilterValue{Pattern: "shouldDropTagValue1"}, "name": filters.FilterValue{Pattern: "metric2"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"shouldDropTagName1", false}: filters.FilterValue{Pattern: "shouldDropTagValue1"},
+			filters.TagFilterValueMapKey{"name", false}:               filters.FilterValue{Pattern: "metric2"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter6, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"shouldDrop2TagName1": filters.FilterValue{Pattern: "shouldDrop2TagValue1"}, "name": filters.FilterValue{Pattern: "metric1"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"shouldDrop2TagName1", false}: filters.FilterValue{Pattern: "shouldDrop2TagValue1"},
+			filters.TagFilterValueMapKey{"name", false}:                filters.FilterValue{Pattern: "metric1"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter7, err := filters.NewTagsFilter(
-		filters.TagFilterValueMap{"shouldNotDropTagName1": filters.FilterValue{Pattern: "shouldNotDropTagValue1"}, "name": filters.FilterValue{Pattern: "metric1"}},
+		filters.TagFilterValueMap{
+			filters.TagFilterValueMapKey{"shouldNotDropTagName1", false}: filters.FilterValue{Pattern: "shouldNotDropTagValue1"},
+			filters.TagFilterValueMapKey{"name", false}:                  filters.FilterValue{Pattern: "metric1"},
+		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
 	)
@@ -5461,7 +5482,7 @@ func testMappingRulesWithNames(t *testing.T) []*mappingRule {
 func testKeepOriginalRollupRules(t *testing.T) []*rollupRule {
 	filter, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue1"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue1"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -5574,8 +5595,8 @@ func testKeepOriginalRollupRules(t *testing.T) []*rollupRule {
 func testRollupRules(t *testing.T) []*rollupRule {
 	filter1, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue1"},
-			"rtagName2": filters.FilterValue{Pattern: "rtagValue2"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue1"},
+			filters.TagFilterValueMapKey{"rtagName2", false}: filters.FilterValue{Pattern: "rtagValue2"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -5583,7 +5604,7 @@ func testRollupRules(t *testing.T) []*rollupRule {
 	require.NoError(t, err)
 	filter2, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue2"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue2"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -5591,7 +5612,7 @@ func testRollupRules(t *testing.T) []*rollupRule {
 	require.NoError(t, err)
 	filter3, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue3"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue3"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -5604,9 +5625,9 @@ func testRollupRules(t *testing.T) []*rollupRule {
 func testRollupRulesWithNames(t *testing.T) []*rollupRule {
 	filter1, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue1"},
-			"rtagName2": filters.FilterValue{Pattern: "rtagValue2"},
-			"name": filters.FilterValue{Pattern: "metric1"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue1"},
+			filters.TagFilterValueMapKey{"rtagName2", false}: filters.FilterValue{Pattern: "rtagValue2"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric1"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -5614,8 +5635,8 @@ func testRollupRulesWithNames(t *testing.T) []*rollupRule {
 	require.NoError(t, err)
 	filter2, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue2"},
-			"name": filters.FilterValue{Pattern: "metric2"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue2"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric2"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),
@@ -5623,8 +5644,8 @@ func testRollupRulesWithNames(t *testing.T) []*rollupRule {
 	require.NoError(t, err)
 	filter3, err := filters.NewTagsFilter(
 		filters.TagFilterValueMap{
-			"rtagName1": filters.FilterValue{Pattern: "rtagValue3"},
-			"name": filters.FilterValue{Pattern: "metric1"},
+			filters.TagFilterValueMapKey{"rtagName1", false}: filters.FilterValue{Pattern: "rtagValue3"},
+			filters.TagFilterValueMapKey{"name", false}:      filters.FilterValue{Pattern: "metric1"},
 		},
 		filters.Conjunction,
 		testTagsFilterOptions(),

--- a/src/metrics/rules/validator/config.go
+++ b/src/metrics/rules/validator/config.go
@@ -142,7 +142,7 @@ type metricTypesValidationConfiguration struct {
 func (c metricTypesValidationConfiguration) NewMetricTypesFn() MetricTypesFn {
 	return func(tagFilters filters.TagFilterValueMap) ([]metric.Type, error) {
 		allowed := make([]metric.Type, 0, len(c.Allowed))
-		filterValue, exists := tagFilters[c.TypeTag]
+		filterValue, exists := tagFilters[filters.NewTagFilterValueMapKey(c.TypeTag, false)]
 		if !exists {
 			// If there is not type filter provided, the filter may match any allowed type.
 			allowed = append(allowed, c.Allowed...)

--- a/src/metrics/rules/validator/config_test.go
+++ b/src/metrics/rules/validator/config_test.go
@@ -301,31 +301,31 @@ allowed:
 		},
 		{
 			filters: filters.TagFilterValueMap{
-				"randomTag": filters.FilterValue{Pattern: "counter"},
+				filters.TagFilterValueMapKey{"randomTag", false}: filters.FilterValue{Pattern: "counter"},
 			},
 			expectedTypes: []metric.Type{metric.CounterType, metric.TimerType, metric.GaugeType},
 		},
 		{
 			filters: filters.TagFilterValueMap{
-				"type": filters.FilterValue{Pattern: "counter"},
+				filters.TagFilterValueMapKey{"type", false}: filters.FilterValue{Pattern: "counter"},
 			},
 			expectedTypes: []metric.Type{metric.CounterType},
 		},
 		{
 			filters: filters.TagFilterValueMap{
-				"type": filters.FilterValue{Pattern: "timer"},
+				filters.TagFilterValueMapKey{"type", false}: filters.FilterValue{Pattern: "timer"},
 			},
 			expectedTypes: []metric.Type{metric.TimerType},
 		},
 		{
 			filters: filters.TagFilterValueMap{
-				"type": filters.FilterValue{Pattern: "gauge"},
+				filters.TagFilterValueMapKey{"type", false}: filters.FilterValue{Pattern: "gauge"},
 			},
 			expectedTypes: []metric.Type{metric.GaugeType},
 		},
 		{
 			filters: filters.TagFilterValueMap{
-				"type": filters.FilterValue{Pattern: "*er"},
+				filters.TagFilterValueMapKey{"type", false}: filters.FilterValue{Pattern: "*er"},
 			},
 			expectedTypes: []metric.Type{metric.CounterType, metric.TimerType},
 		},
@@ -353,10 +353,10 @@ allowed:
 
 	inputs := []filters.TagFilterValueMap{
 		filters.TagFilterValueMap{
-			"type": filters.FilterValue{Pattern: "a[b"},
+			filters.TagFilterValueMapKey{"type", false}: filters.FilterValue{Pattern: "a[b"},
 		},
 		filters.TagFilterValueMap{
-			"type": filters.FilterValue{Pattern: "ab{"},
+			filters.TagFilterValueMapKey{"type", false}: filters.FilterValue{Pattern: "ab{"},
 		},
 	}
 	for _, input := range inputs {

--- a/src/metrics/rules/validator/validator.go
+++ b/src/metrics/rules/validator/validator.go
@@ -203,10 +203,10 @@ func (v *validator) validateFilter(f string) (filters.TagFilterValueMap, error) 
 	}
 	for tag := range filterValues {
 		// Validating the filter tag name does not contain invalid chars.
-		if err := v.opts.CheckInvalidCharactersForTagName(tag); err != nil {
-			return nil, fmt.Errorf("tag name '%s' contains invalid character, err: %v", tag, err)
+		if err := v.opts.CheckInvalidCharactersForTagName(tag.Name); err != nil {
+			return nil, fmt.Errorf("tag name '%s' contains invalid character, err: %v", tag.Name, err)
 		}
-		if err := v.opts.CheckFilterTagNameValid(tag); err != nil {
+		if err := v.opts.CheckFilterTagNameValid(tag.Name); err != nil {
 			return nil, err
 		}
 	}
@@ -277,14 +277,14 @@ func (v *validator) validateStoragePolicies(
 }
 
 // validatePipeline validates the rollup pipeline as follows:
-// * The pipeline must contain at least one operation.
-// * The pipeline can contain at most one aggregation operation, and if there is one,
-//   it must be the first operation.
-// * The pipeline can contain arbitrary number of transformation operations. However,
-//   the transformation derivative order computed from the list of transformations must
-//   be no more than the maximum transformation derivative order that is supported.
-// * The pipeline must contain at least one rollup operation and at most `n` rollup operations,
-//   where `n` is the maximum supported number of rollup levels.
+//   - The pipeline must contain at least one operation.
+//   - The pipeline can contain at most one aggregation operation, and if there is one,
+//     it must be the first operation.
+//   - The pipeline can contain arbitrary number of transformation operations. However,
+//     the transformation derivative order computed from the list of transformations must
+//     be no more than the maximum transformation derivative order that is supported.
+//   - The pipeline must contain at least one rollup operation and at most `n` rollup operations,
+//     where `n` is the maximum supported number of rollup levels.
 func (v *validator) validatePipeline(pipeline mpipeline.Pipeline, types []metric.Type) error {
 	if pipeline.IsEmpty() {
 		return errEmptyPipeline

--- a/src/metrics/rules/validator/validator_test.go
+++ b/src/metrics/rules/validator/validator_test.go
@@ -1785,8 +1785,9 @@ func testKVNamespaceValidator(t *testing.T) namespace.Validator {
 }
 
 func testMetricTypesFn() MetricTypesFn {
-	return func(filters filters.TagFilterValueMap) ([]metric.Type, error) {
-		fv, exists := filters[testTypeTag]
+	return func(filtersMap filters.TagFilterValueMap) ([]metric.Type, error) {
+		key := filters.NewTagFilterValueMapKey(testTypeTag, false)
+		fv, exists := filtersMap[key]
 		if !exists {
 			return []metric.Type{metric.UnknownType}, nil
 		}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding support to exclude certain label keys in aggregation rules. For simplicity, we only allow exclude rules with Conjunction (AND) and not Disjunction (OR)

For example,
```
tagName1=tagValue1 !tagName2:*
```

will result in the following:
```
foo tagName1=tagValue1 tagName3=tagValue3   MATCH
foo tagName1=tagValue1 tagName2=tagValue2   NOT MATCH
```

This is needed for certain aggregation rules like
`container_cpu_usage_seconds_total:counter_sum` which apply on both DP & non-DP nodes

## Testing

[x] Updated UTs and verified that all UTs in `src/metrics` pass
```
go test ./src/metrics/...
ok  	github.com/m3db/m3/src/metrics/aggregation	(cached)
ok  	github.com/m3db/m3/src/metrics/carbon	(cached)
?   	github.com/m3db/m3/src/metrics/encoding	[no test files]
ok  	github.com/m3db/m3/src/metrics/encoding/protobuf	(cached)
?   	github.com/m3db/m3/src/metrics/errors	[no test files]
ok  	github.com/m3db/m3/src/metrics/filters	(cached)
?   	github.com/m3db/m3/src/metrics/generated/mocks	[no test files]
?   	github.com/m3db/m3/src/metrics/generated/proto	[no test files]
?   	github.com/m3db/m3/src/metrics/generated/proto/aggregationpb	[no test files]
ok  	github.com/m3db/m3/src/metrics/generated/proto/metricpb	(cached)
?   	github.com/m3db/m3/src/metrics/generated/proto/pipelinepb	[no test files]
?   	github.com/m3db/m3/src/metrics/generated/proto/policypb	[no test files]
?   	github.com/m3db/m3/src/metrics/generated/proto/rulepb	[no test files]
?   	github.com/m3db/m3/src/metrics/generated/proto/transformationpb	[no test files]
?   	github.com/m3db/m3/src/metrics/integration	[no test files]
ok  	github.com/m3db/m3/src/metrics/matcher	(cached)
ok  	github.com/m3db/m3/src/metrics/matcher/cache	(cached)
?   	github.com/m3db/m3/src/metrics/matcher/namespace	[no test files]
ok  	github.com/m3db/m3/src/metrics/metadata	(cached)
ok  	github.com/m3db/m3/src/metrics/metric	(cached)
ok  	github.com/m3db/m3/src/metrics/metric/aggregated	(cached)
ok  	github.com/m3db/m3/src/metrics/metric/id	(cached)
ok  	github.com/m3db/m3/src/metrics/metric/id/m3	(cached)
ok  	github.com/m3db/m3/src/metrics/metric/unaggregated	(cached)
ok  	github.com/m3db/m3/src/metrics/pipeline	(cached)
ok  	github.com/m3db/m3/src/metrics/pipeline/applied	(cached)
ok  	github.com/m3db/m3/src/metrics/policy	(cached)
ok  	github.com/m3db/m3/src/metrics/rules	(cached)
ok  	github.com/m3db/m3/src/metrics/rules/store/kv	(cached)
ok  	github.com/m3db/m3/src/metrics/rules/validator	(cached)
?   	github.com/m3db/m3/src/metrics/rules/validator/namespace	[no test files]
ok  	github.com/m3db/m3/src/metrics/rules/validator/namespace/kv	(cached)
ok  	github.com/m3db/m3/src/metrics/rules/validator/namespace/static	(cached)
ok  	github.com/m3db/m3/src/metrics/rules/view	(cached)
ok  	github.com/m3db/m3/src/metrics/rules/view/changes	(cached)
ok  	github.com/m3db/m3/src/metrics/transformation	(cached)
?   	github.com/m3db/m3/src/metrics/x/bytes	[no test files]
```


